### PR TITLE
fix: export enum schemas directly with original names as primary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.2] - 2026-03-26
+
+### Fixed
+
+- Enum schemas defined in `components.schemas` are now exported directly with their original names as primary, while operation-specific generated names become aliases
+
 ## [0.21.1] - 2026-03-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualisero/openapi-endpoint",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "MIT",
       "bin": {
         "openapi-codegen": "bin/openapi-codegen.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/qualisero/openapi-endpoint.git"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -500,6 +500,13 @@ function extractEnumsFromSpec(openApiSpec: OpenAPISpec): EnumInfo[] {
     }
   }
 
+  // Export enum schemas directly from components.schemas
+  // This MUST come before property/parameter extraction so the schema name becomes primary
+  // and operation-specific generated names become aliases
+  for (const [schemaName, enumValues] of schemaEnumLookup) {
+    addEnumIfUnique(schemaName, enumValues, `components.schemas.${schemaName}`, enums, seenEnumValues)
+  }
+
   // Helper to resolve enum values from a schema (inline or $ref)
   function resolveEnumValues(schema: OpenAPISchema): (string | number)[] | null {
     // Inline enum


### PR DESCRIPTION
Enum schemas defined in `components.schemas` are now exported directly with their original names as primary, while operation-specific generated names become aliases.