### PR TITLE
fix: skip enum schemas in api-schemas.ts type exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.3] - 2026-03-26
+
+### Fixed
+
+- Skip enum schemas in `api-schemas.ts` type exports (they're already exported as runtime objects in `api-enums.ts`)
+
 ## [0.21.2] - 2026-03-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualisero/openapi-endpoint",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "license": "MIT",
       "bin": {
         "openapi-codegen": "bin/openapi-codegen.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/qualisero/openapi-endpoint.git"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -914,8 +914,17 @@ import type { components } from './openapi-types'
  */
 `
 
+  // Build set of enum schema names to skip (they're exported in api-enums.ts as runtime objects)
+  const enumSchemaNames = new Set<string>()
+  for (const [schemaName, schema] of Object.entries(openApiSpec.components.schemas)) {
+    if (schema.enum && Array.isArray(schema.enum)) {
+      enumSchemaNames.add(schemaName)
+    }
+  }
+
   const schemaExports = Object.keys(openApiSpec.components.schemas)
     .sort()
+    .filter((schemaName) => !enumSchemaNames.has(schemaName)) // Skip enum schemas
     .map((schemaName) => {
       // Remove schema suffix and convert to PascalCase
       const cleanedName = removeSchemaSuffix(schemaName)


### PR DESCRIPTION
Enum schemas are now skipped in `api-schemas.ts` type exports since they're already exported as runtime objects in `api-enums.ts`.