### PR TITLE
chore: release 0.21.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.5] - 2026-05-26
+
+### Fixed
+
+- DELETE mutation no longer triggers spurious GET refetch by skipping item-level cache invalidation
+- List path invalidation still runs as expected after DELETE
+
 ## [0.21.4] - 2026-05-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualisero/openapi-endpoint",
-      "version": "0.21.4",
+      "version": "0.21.5",
       "license": "MIT",
       "bin": {
         "openapi-codegen": "bin/openapi-codegen.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/qualisero/openapi-endpoint.git"


### PR DESCRIPTION
## Summary\n- Bump package version to 0.21.5 to publish the DELETE mutation invalidation fix\n- Update changelog for 0.21.5\n\n## Validation\n- pnpm test:run tests/unit/mutation-typing.test.ts\n- pnpm build\n- pnpm check