### PR TITLE
feat: add serialize mutation option for queued (serialised) mutations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ AGENT_DOCS
 .ralph
 AGENTS.md
 
+# Subagent chain artifacts
+.pi-subagents/
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Subagent artifacts
+.pi-subagents/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-18
+
+### Added
+
+- `serialize` option on `useMutation` for first-class serialised (queued) mutations. `serialize: true` derives an automatic scope id from the operation's resolved path so mutations targeting the same resource queue in submission order; `serialize: 'group-id'` uses a literal scope id for cross-operation queueing. Maps to TanStack Query v5 `scope`; an explicit `scope` always takes precedence.
+
 ## [0.22.0] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `serialize` option on `useMutation` for first-class serialised (queued) mutations. `serialize: true` derives an automatic scope id from the operation's resolved path so mutations targeting the same resource queue in submission order; `serialize: 'group-id'` uses a literal scope id for cross-operation queueing. Maps to TanStack Query v5 `scope`; an explicit `scope` always takes precedence.
+- `serialize` option on `useMutation` for first-class serialised (queued) mutations. `serialize: true` derives an automatic scope id from the operation's resolved path so mutations targeting the same resource queue in submission order; a string uses a literal scope id (used verbatim, including `''`) for cross-operation queueing. Maps to TanStack Query v5 `scope`; an explicit `scope` always takes precedence.
 
 ## [0.22.0] - 2026-05-27
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,31 @@ const mutation = api.createPet.useMutation({
 })
 ```
 
+### Serialised mutations
+
+The `serialize` option queues mutations so they run one at a time in submission order, preventing last-write-wins races in auto-save flows. It maps directly to TanStack Query v5's `scope` mechanism.
+
+```typescript
+// Auto-scope: derived from the resolved path — same resource, same queue
+const patch = api.updateContract.useMutation({ contract_id: '123' }, { serialize: true })
+await patch.mutateAsync({ data: changes1 })
+await patch.mutateAsync({ data: changes2 }) // waits for changes1 to complete first
+
+// String scope: share a queue across different operations
+const updatePet = api.updatePet.useMutation({ petId: '1' }, { serialize: 'pet-editor' })
+const updateStatus = api.updatePetStatus.useMutation({ petId: '1' }, { serialize: 'pet-editor' })
+// Both mutations queue behind each other in submission order
+
+// Raw TanStack scope passthrough also works without serialize:
+const mutation = api.updatePet.useMutation({ petId: '1' }, { scope: { id: 'my-scope' } })
+```
+
+**`serialize: true` scope derivation:** the scope id is `serialize:<METHOD>:<resolvedPath>`, e.g. `serialize:PATCH:/api/contract/123`. Two components mutating the same resource (same path params at hook time) share a queue automatically; different resources do not block each other.
+
+**Deferred path params caveat:** when path parameters are supplied at `mutateAsync` time rather than hook time, the scope id falls back to the path template (e.g. `serialize:PATCH:/api/contract/{contract_id}`), serialising all mutations of that operation regardless of target resource. For per-resource granularity, supply path parameters at hook-creation time or use a string scope.
+
+**Explicit `scope` always wins:** if both `scope` and `serialize` are set, `scope` takes precedence and a warning is logged.
+
 ### Axios Configuration
 
 Pass custom Axios options through the `axiosOptions` parameter for advanced HTTP configuration:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualisero/openapi-endpoint",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "bin": {
         "openapi-codegen": "bin/openapi-codegen.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/qualisero/openapi-endpoint.git"

--- a/src/openapi-mutation.ts
+++ b/src/openapi-mutation.ts
@@ -122,14 +122,17 @@ export function useEndpointMutation<
   // explicit scope is present, derive the scope id from the resolved path (or
   // fall back to the path template when path params are still unresolved).
   const explicitScope = (useMutationOptions as { scope?: { id: string } }).scope
-  if (serialize && explicitScope) {
+  // A string scope id is used verbatim, so any string (including '') enables
+  // serialization; only `undefined`/`false` mean "not set".
+  const serializeEnabled = serialize !== undefined && serialize !== false
+  if (serializeEnabled && explicitScope) {
     console.warn(
       `[openapi-endpoint] Both 'serialize' and 'scope' are set on mutation '${config.path}'. ` +
         `Explicit 'scope' takes precedence; 'serialize' will be ignored.`,
     )
   }
   const serializeScope =
-    !explicitScope && serialize
+    !explicitScope && serializeEnabled
       ? { id: typeof serialize === 'string' ? serialize : `serialize:${config.method}:${resolvedPath.value}` }
       : undefined
 

--- a/src/openapi-mutation.ts
+++ b/src/openapi-mutation.ts
@@ -104,6 +104,7 @@ export function useEndpointMutation<
     invalidateOperations,
     refetchEndpoints,
     queryParams,
+    serialize,
     ...useMutationOptions
   } = resolvedOptions
 
@@ -115,6 +116,22 @@ export function useEndpointMutation<
     queryParams: resolvedQueryParams,
     pathParams: allPathParams,
   } = useResolvedOperation(config.path, resolvedPathParamsInput, queryParams, extraPathParams)
+
+  // Compute the serialization scope. Explicit caller `scope` (passed through
+  // useMutationOptions) always takes priority. When `serialize` is set and no
+  // explicit scope is present, derive the scope id from the resolved path (or
+  // fall back to the path template when path params are still unresolved).
+  const explicitScope = (useMutationOptions as { scope?: { id: string } }).scope
+  if (serialize && explicitScope) {
+    console.warn(
+      `[openapi-endpoint] Both 'serialize' and 'scope' are set on mutation '${config.path}'. ` +
+        `Explicit 'scope' takes precedence; 'serialize' will be ignored.`,
+    )
+  }
+  const serializeScope =
+    !explicitScope && serialize
+      ? { id: typeof serialize === 'string' ? serialize : `serialize:${config.method}:${resolvedPath.value}` }
+      : undefined
 
   const mutation = useMutation(
     {
@@ -259,6 +276,7 @@ export function useEndpointMutation<
       onSettled: () => {
         extraPathParams.value = {}
       },
+      ...(serializeScope && { scope: serializeScope }),
       ...useMutationOptions,
     },
     config.queryClient,

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,6 +243,21 @@ export type MutationOptions<
   CacheInvalidationOptions & {
     axiosOptions?: AxiosRequestConfigExtended
     queryParams?: ReactiveOr<TQueryParams>
+    /**
+     * Serialise this mutation with others sharing the same scope: queued
+     * mutations run one at a time in submission order (TanStack `scope`).
+     * `true` derives the scope id from the operation's resolved path;
+     * a string is used as the scope id verbatim.
+     *
+     * When path parameters are deferred to mutate-time, `true` falls back to
+     * the path template (e.g. `serialize:PATCH:/pets/{petId}`), serialising
+     * all mutations of that operation. For per-resource granularity with
+     * deferred params, supply path parameters at hook-time or use a string scope.
+     *
+     * An explicit `scope` option from the caller always takes precedence over
+     * `serialize`. A warning is emitted when both are set.
+     */
+    serialize?: boolean | string
   }
 
 // ============================================================================

--- a/tests/typing/mutation-serialize.ts
+++ b/tests/typing/mutation-serialize.ts
@@ -1,0 +1,99 @@
+/**
+ * Compile-time typing assertions for the `serialize` mutation option.
+ *
+ * This file is never executed — it is checked by `npm run types:test`
+ * (`npx tsc --noEmit --project tests/tsconfig.json`) to ensure the type
+ * of `serialize` is exactly `boolean | string | undefined`.
+ */
+import { createApiClient } from '../fixtures/api-client'
+import { mockAxios } from '../setup'
+
+// =============================================================================
+// Test 1: serialize: true (boolean) is accepted
+// =============================================================================
+
+function testSerializeBoolean() {
+  const api = createApiClient(mockAxios)
+
+  // boolean literal true — must not produce a type error
+  const _mutation = api.createPet.useMutation({ serialize: true })
+
+  // boolean literal false — must not produce a type error
+  const _mutationFalse = api.createPet.useMutation({ serialize: false })
+
+  // boolean variable — must not produce a type error
+  const flag: boolean = Math.random() > 0.5
+  const _mutationBoolVar = api.createPet.useMutation({ serialize: flag })
+
+  return { _mutation, _mutationFalse, _mutationBoolVar }
+}
+
+// =============================================================================
+// Test 2: serialize: 'group' (string) is accepted
+// =============================================================================
+
+function testSerializeString() {
+  const api = createApiClient(mockAxios)
+
+  // string literal — must not produce a type error
+  const _mutation = api.createPet.useMutation({ serialize: 'group' })
+
+  // general string variable — must not produce a type error
+  const scope: string = 'contract-editor'
+  const _mutationStrVar = api.createPet.useMutation({ serialize: scope })
+
+  return { _mutation, _mutationStrVar }
+}
+
+// =============================================================================
+// Test 3: serialize: 123 (number) is rejected
+// =============================================================================
+
+function testSerializeNumberRejected() {
+  const api = createApiClient(mockAxios)
+
+  // @ts-expect-error — number is not assignable to boolean | string
+  const _mutation = api.createPet.useMutation({ serialize: 123 })
+
+  return { _mutation }
+}
+
+// =============================================================================
+// Test 4: serialize works on mutations with path params too
+// =============================================================================
+
+function testSerializeWithPathParams() {
+  const api = createApiClient(mockAxios)
+
+  // serialize: true with eager path params
+  const _m1 = api.updatePet.useMutation({ petId: '123' }, { serialize: true })
+
+  // serialize: 'group' cross-operation
+  const _m2 = api.updatePet.useMutation({ petId: '123' }, { serialize: 'resource-editor' })
+
+  return { _m1, _m2 }
+}
+
+// =============================================================================
+// Test 5: serialize omitted (undefined) — no type error
+// =============================================================================
+
+function testSerializeOmitted() {
+  const api = createApiClient(mockAxios)
+
+  // option entirely absent — must not produce a type error
+  const _mutation = api.createPet.useMutation({})
+
+  // option explicitly undefined — must not produce a type error
+  const _mutationUndef = api.createPet.useMutation({ serialize: undefined })
+
+  return { _mutation, _mutationUndef }
+}
+
+export {
+  testSerializeBoolean,
+  testSerializeString,
+  testSerializeNumberRejected,
+  testSerializeWithPathParams,
+  testSerializeOmitted,
+}

--- a/tests/unit/mutation-serialize.test.ts
+++ b/tests/unit/mutation-serialize.test.ts
@@ -171,6 +171,42 @@ describe('serialize mutation option', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // (c2) serialize:'' (empty string) is used verbatim and still serializes
+  // ---------------------------------------------------------------------------
+  it("serialize:'' (empty string) is a valid verbatim scope id and serializes", async () => {
+    const first = run(() => api.createPet.useMutation({ serialize: '' }))
+    const second = run(() => api.createPet.useMutation({ serialize: '' }))
+
+    let resolveFirst!: () => void
+    const firstStarted = vi.fn()
+    const secondStarted = vi.fn()
+
+    mockAxios.mockImplementationOnce(() => {
+      firstStarted()
+      return new Promise((r) => {
+        resolveFirst = () => r({ data: { id: '1', name: 'A' } })
+      })
+    })
+    mockAxios.mockImplementationOnce(() => {
+      secondStarted()
+      return Promise.resolve({ data: { id: '2', name: 'B' } })
+    })
+
+    const p1 = first.mutateAsync({ data: { name: 'A' } })
+    const p2 = second.mutateAsync({ data: { name: 'B' } })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // First started, second queued behind the shared empty-string scope
+    expect(firstStarted).toHaveBeenCalledTimes(1)
+    expect(secondStarted).toHaveBeenCalledTimes(0)
+
+    resolveFirst()
+    await Promise.all([p1, p2])
+    expect(secondStarted).toHaveBeenCalledTimes(1)
+  })
+
+  // ---------------------------------------------------------------------------
   // (d) Explicit scope + serialize → explicit scope wins, dev warning emitted once
   // ---------------------------------------------------------------------------
   it('explicit scope takes precedence over serialize and emits a dev warning', async () => {

--- a/tests/unit/mutation-serialize.test.ts
+++ b/tests/unit/mutation-serialize.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for the `serialize` mutation option.
+ *
+ * The `serialize` option maps to TanStack Query v5's `scope: { id }` mechanism:
+ * mutations sharing the same scope id run serially in submission order. The
+ * second mutation is paused until the first settles (success or error).
+ *
+ * `serialize: true`      → scope id derived from the operation's resolved path
+ * `serialize: 'group'`   → that string used verbatim as the scope id
+ * explicit `scope` wins over `serialize` (dev warning emitted when both set)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { effectScope } from 'vue'
+import { createApiClient } from '../fixtures/api-client'
+import { createTestScope } from '../helpers'
+import { mockAxios } from '../setup'
+
+describe('serialize mutation option', () => {
+  let api: ReturnType<typeof createApiClient>
+  let scope: ReturnType<typeof effectScope>
+  let run: <T>(fn: () => T) => T
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;({ api, scope, run } = createTestScope())
+  })
+
+  afterEach(() => {
+    scope.stop()
+  })
+
+  // ---------------------------------------------------------------------------
+  // (a) Two mutateAsync calls with serialize:true run sequentially
+  // ---------------------------------------------------------------------------
+  it('two mutateAsync calls with serialize:true run sequentially — 2nd starts only after 1st resolves', async () => {
+    const mutation = run(() => api.createPet.useMutation({ serialize: true }))
+
+    // Deferred-promise pattern: we control when each axios call settles
+    let resolveFirst!: () => void
+    let resolveSecond!: () => void
+
+    const firstStarted = vi.fn()
+    const secondStarted = vi.fn()
+
+    mockAxios.mockImplementationOnce(() => {
+      firstStarted()
+      return new Promise((r) => {
+        resolveFirst = () => r({ data: { id: '1', name: 'First' } })
+      })
+    })
+    mockAxios.mockImplementationOnce(() => {
+      secondStarted()
+      return new Promise((r) => {
+        resolveSecond = () => r({ data: { id: '2', name: 'Second' } })
+      })
+    })
+
+    // Fire both calls without awaiting — they run in parallel at the JS level
+    const p1 = mutation.mutateAsync({ data: { name: 'First' } })
+    const p2 = mutation.mutateAsync({ data: { name: 'Second' } })
+
+    // Give the event loop a moment to start the first mutation
+    await new Promise((r) => setTimeout(r, 10))
+
+    // First should have started, second should still be waiting (scope-queued)
+    expect(firstStarted).toHaveBeenCalledTimes(1)
+    expect(secondStarted).toHaveBeenCalledTimes(0)
+
+    // Resolve the first call
+    resolveFirst()
+    await p1
+
+    // Give the mutation cache a tick to enqueue the next mutation
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Now the second should have started
+    expect(secondStarted).toHaveBeenCalledTimes(1)
+
+    resolveSecond()
+    await p2
+
+    expect(mockAxios).toHaveBeenCalledTimes(2)
+  })
+
+  // ---------------------------------------------------------------------------
+  // (b) Guard test: without serialize, same two calls run concurrently
+  // ---------------------------------------------------------------------------
+  it('without serialize, two calls run concurrently', async () => {
+    const mutation = run(() => api.createPet.useMutation())
+
+    let resolveFirst!: () => void
+    let resolveSecond!: () => void
+
+    const firstStarted = vi.fn()
+    const secondStarted = vi.fn()
+
+    mockAxios.mockImplementationOnce(() => {
+      firstStarted()
+      return new Promise((r) => {
+        resolveFirst = () => r({ data: { id: '1', name: 'First' } })
+      })
+    })
+    mockAxios.mockImplementationOnce(() => {
+      secondStarted()
+      return new Promise((r) => {
+        resolveSecond = () => r({ data: { id: '2', name: 'Second' } })
+      })
+    })
+
+    const p1 = mutation.mutateAsync({ data: { name: 'First' } })
+    const p2 = mutation.mutateAsync({ data: { name: 'Second' } })
+
+    // Give both a moment to start
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Both should run concurrently — both axios calls started before the first resolved
+    expect(firstStarted).toHaveBeenCalledTimes(1)
+    expect(secondStarted).toHaveBeenCalledTimes(1)
+
+    resolveFirst()
+    resolveSecond()
+    await Promise.all([p1, p2])
+  })
+
+  // ---------------------------------------------------------------------------
+  // (c) serialize:'group' shares scope across two different operations
+  // ---------------------------------------------------------------------------
+  it("serialize:'group' queues two different operations behind each other", async () => {
+    // Two distinct operations that share the same string scope
+    const updateMutation = run(() => api.updatePet.useMutation({ petId: '42' }, { serialize: 'group' }))
+    const deleteMutation = run(() => api.deletePet.useMutation({ petId: '42' }, { serialize: 'group' }))
+
+    let resolveUpdate!: () => void
+    let resolveDelete!: () => void
+
+    const updateStarted = vi.fn()
+    const deleteStarted = vi.fn()
+
+    mockAxios.mockImplementationOnce(() => {
+      updateStarted()
+      return new Promise((r) => {
+        resolveUpdate = () => r({ data: { id: '42', name: 'Updated' } })
+      })
+    })
+    mockAxios.mockImplementationOnce(() => {
+      deleteStarted()
+      return new Promise((r) => {
+        resolveDelete = () => r({ data: {} })
+      })
+    })
+
+    const p1 = updateMutation.mutateAsync({ data: { name: 'Updated' } })
+    const p2 = deleteMutation.mutateAsync()
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // update started, delete is queued
+    expect(updateStarted).toHaveBeenCalledTimes(1)
+    expect(deleteStarted).toHaveBeenCalledTimes(0)
+
+    resolveUpdate()
+    await p1
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Now delete should have started
+    expect(deleteStarted).toHaveBeenCalledTimes(1)
+
+    resolveDelete()
+    await p2
+  })
+
+  // ---------------------------------------------------------------------------
+  // (d) Explicit scope + serialize → explicit scope wins, dev warning emitted once
+  // ---------------------------------------------------------------------------
+  it('explicit scope takes precedence over serialize and emits a dev warning', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const explicitScopeId = 'my-explicit-scope'
+    const mutation = run(() =>
+      api.createPet.useMutation({
+        scope: { id: explicitScopeId },
+        serialize: true,
+      }),
+    )
+
+    mockAxios.mockResolvedValueOnce({ data: { id: '1', name: 'Test' } })
+
+    await mutation.mutateAsync({ data: { name: 'Test' } })
+
+    // Warning should have been emitted exactly once (at hook creation time)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('serialize')
+    expect(warnSpy.mock.calls[0][0]).toContain('scope')
+
+    // The actual request should have gone through (explicit scope did not block it)
+    expect(mockAxios).toHaveBeenCalledTimes(1)
+
+    warnSpy.mockRestore()
+  })
+
+  // ---------------------------------------------------------------------------
+  // (e) Order preservation: payloads arrive in submission order
+  // ---------------------------------------------------------------------------
+  it('payloads arrive server-side in submission order', async () => {
+    const mutation = run(() => api.createPet.useMutation({ serialize: true }))
+
+    const callOrder: string[] = []
+
+    let resolveFirst!: () => void
+    let resolveSecond!: () => void
+    let resolveThird!: () => void
+
+    mockAxios.mockImplementationOnce((cfg: { data: { name: string } }) => {
+      callOrder.push(cfg.data.name)
+      return new Promise((r) => {
+        resolveFirst = () => r({ data: { id: '1', name: cfg.data.name } })
+      })
+    })
+    mockAxios.mockImplementationOnce((cfg: { data: { name: string } }) => {
+      callOrder.push(cfg.data.name)
+      return new Promise((r) => {
+        resolveSecond = () => r({ data: { id: '2', name: cfg.data.name } })
+      })
+    })
+    mockAxios.mockImplementationOnce((cfg: { data: { name: string } }) => {
+      callOrder.push(cfg.data.name)
+      return new Promise((r) => {
+        resolveThird = () => r({ data: { id: '3', name: cfg.data.name } })
+      })
+    })
+
+    const p1 = mutation.mutateAsync({ data: { name: 'Alpha' } })
+    const p2 = mutation.mutateAsync({ data: { name: 'Beta' } })
+    const p3 = mutation.mutateAsync({ data: { name: 'Gamma' } })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    resolveFirst()
+    await p1
+    await new Promise((r) => setTimeout(r, 10))
+
+    resolveSecond()
+    await p2
+    await new Promise((r) => setTimeout(r, 10))
+
+    resolveThird()
+    await p3
+
+    expect(callOrder).toEqual(['Alpha', 'Beta', 'Gamma'])
+  })
+
+  // ---------------------------------------------------------------------------
+  // (f) Error in first mutation does not block the queued second
+  // ---------------------------------------------------------------------------
+  it('error in first mutation does not block the queued second', async () => {
+    const mutation = run(() => api.createPet.useMutation({ serialize: true }))
+
+    let rejectFirst!: (reason: Error) => void
+    let resolveSecond!: () => void
+
+    const secondStarted = vi.fn()
+
+    mockAxios.mockImplementationOnce(() => {
+      return new Promise((_resolve, reject) => {
+        rejectFirst = reject
+      })
+    })
+    mockAxios.mockImplementationOnce(() => {
+      secondStarted()
+      return new Promise((r) => {
+        resolveSecond = () => r({ data: { id: '2', name: 'Second' } })
+      })
+    })
+
+    const p1 = mutation.mutateAsync({ data: { name: 'Fail' } })
+    const p2 = mutation.mutateAsync({ data: { name: 'Second' } })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Reject the first mutation
+    rejectFirst(new Error('network error'))
+    await expect(p1).rejects.toThrow('network error')
+
+    // Give the cache a tick to move to the next mutation
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Second should now have started despite the first failing
+    expect(secondStarted).toHaveBeenCalledTimes(1)
+
+    resolveSecond()
+    const result = await p2
+    expect(result.data).toEqual({ id: '2', name: 'Second' })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Smoke test: serialize does not leak into axios call config
+  // ---------------------------------------------------------------------------
+  it('serialize option is not forwarded to axios request config', async () => {
+    const mutation = run(() => api.createPet.useMutation({ serialize: true }))
+
+    mockAxios.mockResolvedValueOnce({ data: { id: '1', name: 'Test' } })
+
+    await mutation.mutateAsync({ data: { name: 'Test' } })
+
+    const callArg = (mockAxios as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>
+    expect(callArg).not.toHaveProperty('serialize')
+  })
+})


### PR DESCRIPTION
## Summary

Adds first-class support for serialised (queued) mutations via a new `serialize` option on `MutationOptions`, wrapping TanStack Query v5 mutation `scope` with an ergonomic, typed, auto-keyed API. Replaces consumer-side hacks (e.g. manual save queues) for auto-save / last-write-wins flows.

## Changes

- **`serialize?: boolean | string`** on `MutationOptions`:
  - `true` derives the scope id from the operation's method + resolved path (e.g. `serialize:PATCH:/api/contract/123`), so mutations of the same resource queue automatically while different resources stay concurrent
  - a string is used verbatim as the scope id for cross-operation grouping
- Explicit `scope` passed by the caller wins over `serialize` (warning emitted once)
- Deferred path params (supplied at `mutateAsync`) fall back to the path-template scope id: coarser but correct, documented in typedoc and README
- `serialize` is stripped before options reach `useMutation` (does not leak)
- Per-call `serialize` on mutation vars deliberately omitted: TanStack `scope` is static per observer, so a per-call override would be a silent no-op

## Tests

- `tests/unit/mutation-serialize.test.ts` (7 tests): sequential execution with deferred-promise mocks, concurrency guard without `serialize`, cross-operation string scope, explicit-scope-wins + single warning, order preservation, error in first does not block queued second, no leak into axios config
- `tests/typing/mutation-serialize.ts`: `boolean | string` accepted, number rejected

## Release

- Version bump 0.22.0 → 0.23.0 (minor, new feature)
- CHANGELOG entry, README 'Serialised mutations' section

## Validation

- `npm run check` (types, types:test, lint, format:check) ✅
- `npx vitest run tests/unit/mutation-serialize.test.ts` → 7/7 ✅

Implements the plan in OPENAPI_SERIAL.md via a reviewed subagent chain (implement → test → review → finalize → quality gate).