### PR TITLE
feat: client-level error policy and typed error channel (v0.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-27
+
+### Added
+
+- Client-level error policy via `createApiErrorCaches`: build your `QueryClient`'s `queryCache` and `mutationCache` from it and pass an `onError` callback that fires **once per logical failure, after retries, and never swallows the rejection** — the right place for a global error banner. The callback receives the error plus the operation's `operationId`, `path`, `method`, and whether it was a query or mutation.
+- `skipGlobalError` per-call opt-out on `useQuery` and `useMutation`: `true` always suppresses the global `onError` policy for that call; a predicate (typed to the operation's error body) suppresses it selectively (e.g. only on 409). The promise rejects either way — this controls the global side-effect only.
+- Typed error channel: `error.value` is now `AxiosError<TError>` carrying the operation's declared error payload (4xx/5xx/`default` JSON bodies), so `error.value?.response?.data?.errors` is fully typed with no casts. Generated `api-operations.ts` exports `ApiErrorData<Op>` and `ApiError<Op>` helpers.
+- `operationId` in the generated endpoint config, enabling the error policy's operation context.
+
+### Changed
+
+- Error type widens from `Error` to `AxiosError<TError>` (default `unknown`) across query/mutation options and return values. `error.value.message` still works (`AxiosError` extends `Error`), but code annotated `: Error` may need updating.
+- Reserved schema names (e.g. a schema literally named `Error`) are now emitted with a `Schema` suffix in `api-schemas.ts` (e.g. `ErrorSchema`) so they don't shadow the global `Error`. The original name remains reachable via `components['schemas']['Error']`.
+
+### Deprecated
+
+- `errorHandler` query option: it swallows the error unless it rethrows, and fires per retry attempt. Use the client-level `onError` policy from `createApiErrorCaches` instead, which observes without swallowing and fires once per logical failure.
+
+### Fixed
+
+- `useEndpointLazyQuery`'s `fetch()` now applies the standard no-retry-on-4xx policy. Previously the lazy fetch inherited the `QueryClient`'s default retry, so a 404 could be retried three times.
+- Deprecated `errorHandler` swallow path now resolves the query with `null` instead of triggering TanStack v5's "Query data cannot be undefined" error state. Queries that use a swallowing `errorHandler` will have `data.value === null` (previously they entered an error state).
+- Generated `api-enums.ts` no longer emits self-alias declarations (`export const X = X`) when a promoted common-suffix enum name coincidentally matches one of its own aliases, which would produce `TS2451` "Cannot redeclare block-scoped variable" errors in the generated output.
+- Caller-supplied `meta` that is a Vue `ref` is now unwrapped before merging with the error-policy identity stamp. Previously the ref's internals (`__v_isRef`, `_value`, …) were spread into `meta` instead of its value.
+- `ApiErrorData` now resolves error bodies for operations whose status keys are quoted numeric strings (e.g. `'404'`), in addition to the unquoted numeric keys `openapi-typescript` emits.
+
 ## [0.24.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenApiEndpoint
 
-[![npm version](https://badge.fury.io/js/@qualisero%2Fopenapi-endpoint.svg?v=0.24.0)](https://badge.fury.io/js/@qualisero%2Fopenapi-endpoint)
-[![CI](https://github.com/qualisero/openapi-endpoint/workflows/CI/badge.svg?refresh=20260722)](https://github.com/qualisero/openapi-endpoint/actions/workflows/ci.yml)
+[![npm version](https://badge.fury.io/js/@qualisero%2Fopenapi-endpoint.svg?v=0.25.0)](https://badge.fury.io/js/@qualisero%2Fopenapi-endpoint)
+[![CI](https://github.com/qualisero/openapi-endpoint/workflows/CI/badge.svg?refresh=20260827)](https://github.com/qualisero/openapi-endpoint/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://qualisero.github.io/openapi-endpoint/)
 
@@ -179,6 +179,70 @@ const mutation = api.updatePet.useMutation({ petId: '1' }, { scope: { id: 'my-sc
 
 **Explicit `scope` always wins:** if both `scope` and `serialize` are set, `scope` takes precedence and a warning is logged.
 
+### Global error policy
+
+`createApiErrorCaches` builds the `queryCache` and `mutationCache` for your `QueryClient` with a single `onError` callback that observes every failure from hooks created by this library. It fires **once per logical failure, after retries**, and **never swallows the rejection** — the right place for a global error banner:
+
+```typescript
+import { createApiClient, createApiErrorCaches } from '@qualisero/openapi-endpoint'
+import { QueryClient } from '@tanstack/vue-query'
+import axios from 'axios'
+
+const { queryCache, mutationCache } = createApiErrorCaches({
+  onError: (error, ctx) => {
+    // ctx: { operationId, path, method, kind: 'query' | 'mutation' }
+    showErrorBanner(`Request to ${ctx.operationId} failed`)
+  },
+})
+
+const queryClient = new QueryClient({ queryCache, mutationCache })
+const api = createApiClient(axios.create({ baseURL: 'https://api.example.com' }), queryClient)
+```
+
+Notes:
+
+- The callback is observe-only: the query or mutation still rejects.
+- It fires for any rejection, including non-axios throws — narrow with `isAxiosError` (from `axios`) inside the callback.
+- Queries and mutations you register yourself (outside the generated hooks) are untouched.
+
+Opt out per call with `skipGlobalError` — `true` always suppresses the global policy for that call, or a predicate typed to the operation's declared error body suppresses it selectively:
+
+```typescript
+// Never trigger the global banner for this query
+const { data } = api.getPet.useQuery({ petId: '123' }, { skipGlobalError: true })
+
+// Skip only specific errors (e.g. you handle 409 inline)
+const createPet = api.createPet.useMutation({
+  skipGlobalError: (e) => e.response?.status === 409,
+})
+```
+
+The promise rejects either way — `skipGlobalError` controls the global side-effect only.
+
+### Typed errors
+
+`error.value` is `AxiosError<TError> | null`, where `TError` is the operation's declared error body (the union of JSON bodies from its 4xx / 5xx / `default` responses). No more casting:
+
+```typescript
+const { error, mutateAsync } = api.createPet.useMutation()
+
+// after a rejection, the declared error body is fully typed:
+error.value?.response?.data?.errors // no cast, no hand-written interface
+```
+
+The generated `api-operations.ts` also exports helpers for use in plain functions:
+
+```typescript
+import type { ApiError, ApiErrorData } from './generated/api-operations'
+
+type PetErrorBody = ApiErrorData<'createPet'>
+function isConflict(e: ApiError<'createPet'>): boolean {
+  return e.response?.status === 409
+}
+```
+
+Operations that declare no JSON error body fall back to `unknown`.
+
 ### Axios Configuration
 
 Pass custom Axios options through the `axiosOptions` parameter for advanced HTTP configuration:
@@ -205,15 +269,12 @@ const { data } = api.getPet.useQuery(
 )
 
 // Request/response transforms
-const { data } = api.createPet.useMutation(
-  {},
-  {
-    axiosOptions: {
-      transformRequest: [(data) => JSON.stringify(data)],
-      transformResponse: [(data) => JSON.parse(data)],
-    },
+const { data } = api.createPet.useMutation({
+  axiosOptions: {
+    transformRequest: [(data) => JSON.stringify(data)],
+    transformResponse: [(data) => JSON.parse(data)],
   },
-)
+})
 
 // Override baseURL for specific requests
 const { data } = api.listPets.useQuery({
@@ -257,7 +318,7 @@ const { data } = api.listPets.useQuery({
 {
   data: ComputedRef<T | undefined>
   isLoading: ComputedRef<boolean>
-  error: ComputedRef<Error | null>
+  error: ComputedRef<AxiosError<TError> | null>
   isEnabled: ComputedRef<boolean>
   queryKey: ComputedRef<unknown[]>
   onLoad: (cb: (data: T) => void) => void
@@ -271,7 +332,7 @@ const { data } = api.listPets.useQuery({
 {
   data: ComputedRef<AxiosResponse<T> | undefined>
   isPending: ComputedRef<boolean>
-  error: ComputedRef<Error | null>
+  error: ComputedRef<AxiosError<TError> | null>
   mutate: (vars) => void
   mutateAsync: (vars) => Promise<AxiosResponse>
   extraPathParams: Ref<PathParams> // for dynamic path params
@@ -347,6 +408,7 @@ For detailed guides, see [docs/manual/](docs/manual/):
 - [File Uploads](docs/manual/05-file-uploads.md)
 - [Cache Management](docs/manual/06-cache-management.md)
 - [Lazy Queries](docs/manual/07-lazy-queries.md)
+- [Global Error Policy](docs/manual/09-error-policy.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ const { data } = api.listPets.useQuery({
 {
   data: ComputedRef<T | undefined>
   isLoading: ComputedRef<boolean>
-  error: ComputedRef<AxiosError<TError> | null>
+  error: Ref<AxiosError<TError> | null>
   isEnabled: ComputedRef<boolean>
   queryKey: ComputedRef<unknown[]>
   onLoad: (cb: (data: T) => void) => void
@@ -332,7 +332,7 @@ const { data } = api.listPets.useQuery({
 {
   data: ComputedRef<AxiosResponse<T> | undefined>
   isPending: ComputedRef<boolean>
-  error: ComputedRef<AxiosError<TError> | null>
+  error: Ref<AxiosError<TError> | null>
   mutate: (vars) => void
   mutateAsync: (vars) => Promise<AxiosResponse>
   extraPathParams: Ref<PathParams> // for dynamic path params

--- a/docs/manual/07-lazy-queries.md
+++ b/docs/manual/07-lazy-queries.md
@@ -298,6 +298,7 @@ You can pass query options (excluding `queryParams`, `onLoad`, and `enabled`):
 const query = api.listPets.useLazyQuery({
   staleTime: 5 * 60 * 1000, // 5 minutes
   errorHandler: async (error) => {
+    // ⚠️ Deprecated — see note below
     console.error('Custom error handler:', error)
     // Return fallback data
     return [{ id: 'fallback', name: 'Fallback' }]
@@ -307,6 +308,11 @@ const query = api.listPets.useLazyQuery({
   },
 })
 ```
+
+> **`errorHandler` is deprecated.** It fires once per retry attempt (not once per logical
+> failure), is gated on `isAxiosError` (non-axios throws bypass it), and silently swallows
+> the rejection unless you rethrow. Use the client-level `onError` policy instead:
+> see [Global error policy](./09-error-policy.md).
 
 ## What's Next?
 

--- a/docs/manual/09-error-policy.md
+++ b/docs/manual/09-error-policy.md
@@ -1,0 +1,84 @@
+# Global Error Policy
+
+This guide covers `createApiErrorCaches` — the client-level hook for observing API errors once
+per logical failure, after all retries, without swallowing the rejection.
+
+## Why a client-level policy?
+
+The deprecated `errorHandler` option fires per retry attempt and silently swallows the rejection
+unless you rethrow. The `QueryCache` / `MutationCache` `onError` hooks fire **once**, after
+retries are exhausted, and the promise always rejects regardless.
+
+For a global error banner, toast, or logger that should trigger exactly once per failed call,
+`createApiErrorCaches` is the right place.
+
+## Setup
+
+Pass `createApiErrorCaches` the `onError` callback, then supply the returned caches to your
+`QueryClient`:
+
+```typescript
+import { QueryClient } from '@tanstack/vue-query'
+import { createApiErrorCaches } from '@qualisero/openapi-endpoint'
+import { isAxiosError } from 'axios'
+
+const { queryCache, mutationCache } = createApiErrorCaches({
+  onError(error, ctx) {
+    // error is unknown — narrow it before accessing network-specific fields.
+    if (isAxiosError(error) && error.response?.status === 401) {
+      router.push('/login')
+      return
+    }
+
+    // ctx carries operation identity
+    console.error(`[${ctx.method} ${ctx.path}] ${ctx.operationId} failed`, error)
+
+    // Show a global banner / toast
+    showErrorBanner('Request failed. Please try again.')
+  },
+})
+
+export const queryClient = new QueryClient({ queryCache, mutationCache })
+```
+
+The `ApiErrorContext` object passed to `onError`:
+
+| Field         | Type                    | Example              |
+| ------------- | ----------------------- | -------------------- |
+| `operationId` | `string`                | `'createVessel'`     |
+| `path`        | `string`                | `'/api/vessel/{id}'` |
+| `method`      | `HttpMethod`            | `'POST'`             |
+| `kind`        | `'query' \| 'mutation'` | `'mutation'`         |
+
+## Suppressing the policy for specific calls
+
+Use `skipGlobalError` on any hook call to opt out:
+
+```typescript
+// Always suppress — you handle this error inline
+const { data } = api.getPet.useQuery({ petId: '123' }, { skipGlobalError: true })
+
+// Suppress selectively — only 409 conflicts are handled inline, other errors go global
+const createPet = api.createPet.useMutation({
+  skipGlobalError: (e) => e.response?.status === 409,
+})
+```
+
+The predicate receives an `AxiosError` typed to the operation's declared error body. The
+promise always rejects regardless of whether the global policy is suppressed.
+
+## Behaviour guarantees
+
+- **Once per logical failure.** `onError` fires after all retries are exhausted, not per attempt.
+- **Never swallows.** The rejection propagates normally; `onError` is observe-only.
+- **No-op for unstamped queries.** Ad-hoc queries registered directly on the `QueryClient`
+  (without the library hooks) do not trigger `onError`, so your pre-existing raw queries are
+  untouched.
+- **Mutations included.** `createApiErrorCaches` wires both the `QueryCache` and `MutationCache`,
+  so `useMutation` failures are covered with `ctx.kind === 'mutation'`.
+
+## What's Next?
+
+- [Lazy Queries](./07-lazy-queries.md) — Manual fetch control with `useLazyQuery`
+- [Cache Management](./06-cache-management.md) — Advanced cache strategies
+- [Axios Configuration](./08-axios-configuration.md) — Custom Axios options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualisero/openapi-endpoint",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "bin": {
         "openapi-codegen": "bin/openapi-codegen.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualisero/openapi-endpoint",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/qualisero/openapi-endpoint.git"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -730,12 +730,15 @@ ${members}
 export type ${enumInfo.name} = typeof ${enumInfo.name}[keyof typeof ${enumInfo.name}]
 `
 
-      // Generate type aliases for duplicates
+      // Generate type aliases for duplicates (skip self-aliases where alias === primary name)
       if (enumInfo.aliases && enumInfo.aliases.length > 0) {
-        output += '\n// Type aliases for duplicate enum values\n'
-        for (const alias of enumInfo.aliases) {
-          output += `export const ${alias} = ${enumInfo.name}\n`
-          output += `export type ${alias} = ${enumInfo.name}\n`
+        const nonSelfAliases = enumInfo.aliases.filter((alias) => alias !== enumInfo.name)
+        if (nonSelfAliases.length > 0) {
+          output += '\n// Type aliases for duplicate enum values\n'
+          for (const alias of nonSelfAliases) {
+            output += `export const ${alias} = ${enumInfo.name}\n`
+            output += `export type ${alias} = ${enumInfo.name}\n`
+          }
         }
       }
 
@@ -827,10 +830,16 @@ import type { components } from './openapi-types'
       const cleanedName = removeSchemaSuffix(schemaName)
       const exportedName = toPascalCase(cleanedName)
 
-      // Only add comment if the name changed
-      const comment = exportedName !== schemaName ? `// Schema: ${schemaName}\n` : ''
+      // Guard against names that shadow built-in globals (e.g. `Error` shadows the global Error constructor).
+      // Suffix them with 'Schema' so the generated alias is unambiguous.
+      // The original components['schemas'][...] access is left unchanged.
+      const RESERVED_EXPORT_NAMES = new Set(['Error'])
+      const safeExportedName = RESERVED_EXPORT_NAMES.has(exportedName) ? `${exportedName}Schema` : exportedName
 
-      return `${comment}export type ${exportedName} = components['schemas']['${schemaName}']`
+      // Only add comment if the name changed (either suffix-stripped or reserved-name-guarded)
+      const comment = safeExportedName !== schemaName ? `// Schema: ${schemaName}\n` : ''
+
+      return `${comment}export type ${safeExportedName} = components['schemas']['${schemaName}']`
     })
     .join('\n\n')
 
@@ -963,25 +972,26 @@ function generateApiClientContent(operationMap: Record<string, OperationInfo>, u
  */
 function _queryNoParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type Response = ${responseType}<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
   const useQuery = (
-    options?: QueryOptions<Response, QueryParams>,
-  ): QueryReturn<Response, Record<string, never>> =>
-    useEndpointQuery<Response, Record<string, never>, QueryParams>(
+    options?: QueryOptions<Response, QueryParams, ErrorData>,
+  ): QueryReturn<Response, Record<string, never>, ErrorData> =>
+    useEndpointQuery<Response, Record<string, never>, QueryParams, ErrorData>(
       { ...base, ...cfg },
       undefined,
       options,
     )
 
   const useLazyQuery = (
-    options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-  ): LazyQueryReturn<Response, Record<string, never>, QueryParams> =>
-    useEndpointLazyQuery<Response, Record<string, never>, QueryParams>(
+    options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+  ): LazyQueryReturn<Response, Record<string, never>, QueryParams, ErrorData> =>
+    useEndpointLazyQuery<Response, Record<string, never>, QueryParams, ErrorData>(
       { ...base, ...cfg },
       undefined,
       options,
@@ -1039,43 +1049,44 @@ function _queryNoParams<Op extends AllOps>(
  */
 function _queryWithParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type PathParams = ApiPathParams<Op>
   type PathParamsInput = ApiPathParamsInput<Op>
   type Response = ${responseType}<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
   // Two-overload interface: non-function (exact via object-literal checking) +
   // getter function (exact via NoExcessReturn constraint).
   type _UseQuery = {
     (
       pathParams: PathParamsInput | Ref<PathParamsInput> | ComputedRef<PathParamsInput>,
-      options?: QueryOptions<Response, QueryParams>,
-    ): QueryReturn<Response, PathParams>
+      options?: QueryOptions<Response, QueryParams, ErrorData>,
+    ): QueryReturn<Response, PathParams, ErrorData>
     <F extends () => PathParamsInput>(
       pathParams: NoExcessReturn<PathParamsInput, F>,
-      options?: QueryOptions<Response, QueryParams>,
-    ): QueryReturn<Response, PathParams>
+      options?: QueryOptions<Response, QueryParams, ErrorData>,
+    ): QueryReturn<Response, PathParams, ErrorData>
   }
 
   type _UseLazyQuery = {
     (
       pathParams: PathParamsInput | Ref<PathParamsInput> | ComputedRef<PathParamsInput>,
-      options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-    ): LazyQueryReturn<Response, PathParams, QueryParams>
+      options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+    ): LazyQueryReturn<Response, PathParams, QueryParams, ErrorData>
     <F extends () => PathParamsInput>(
       pathParams: NoExcessReturn<PathParamsInput, F>,
-      options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-    ): LazyQueryReturn<Response, PathParams, QueryParams>
+      options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+    ): LazyQueryReturn<Response, PathParams, QueryParams, ErrorData>
   }
 
   const _impl = (
     pathParams: ReactiveOr<PathParamsInput>,
-    options?: QueryOptions<Response, QueryParams>,
-  ): QueryReturn<Response, PathParams> =>
-    useEndpointQuery<Response, PathParams, QueryParams>(
+    options?: QueryOptions<Response, QueryParams, ErrorData>,
+  ): QueryReturn<Response, PathParams, ErrorData> =>
+    useEndpointQuery<Response, PathParams, QueryParams, ErrorData>(
       { ...base, ...cfg },
       pathParams as _PathParamsCast,
       options,
@@ -1083,9 +1094,9 @@ function _queryWithParams<Op extends AllOps>(
 
   const _lazyImpl = (
     pathParams: ReactiveOr<PathParamsInput>,
-    options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-  ): LazyQueryReturn<Response, PathParams, QueryParams> =>
-    useEndpointLazyQuery<Response, PathParams, QueryParams>(
+    options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+  ): LazyQueryReturn<Response, PathParams, QueryParams, ErrorData> =>
+    useEndpointLazyQuery<Response, PathParams, QueryParams, ErrorData>(
       { ...base, ...cfg },
       pathParams as _PathParamsCast,
       options,
@@ -1158,17 +1169,18 @@ function _queryWithParams<Op extends AllOps>(
  */
 function _mutationNoParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type RequestBody = ApiRequest<Op>
   type Response = ${responseType}<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
   const useMutation = (
-    options?: MutationOptions<Response, Record<string, never>, RequestBody, QueryParams>,
-  ): MutationReturn<Response, Record<string, never>, RequestBody, QueryParams> =>
-    useEndpointMutation<Response, Record<string, never>, RequestBody, QueryParams>(
+    options?: MutationOptions<Response, Record<string, never>, RequestBody, QueryParams, ErrorData>,
+  ): MutationReturn<Response, Record<string, never>, RequestBody, QueryParams, ErrorData> =>
+    useEndpointMutation<Response, Record<string, never>, RequestBody, QueryParams, ErrorData>(
       { ...base, ...cfg },
       undefined,
       options,
@@ -1201,7 +1213,7 @@ function _mutationNoParams<Op extends AllOps>(
  */
 function _mutationWithParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type PathParams = ApiPathParams<Op>
@@ -1209,6 +1221,7 @@ function _mutationWithParams<Op extends AllOps>(
   type RequestBody = ApiRequest<Op>
   type Response = ${responseType}<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
   // Three-overload interface:
   // 1. Deferred path params — omit or pass undefined/null; supply at mutateAsync() time via pathParams variable
@@ -1217,23 +1230,23 @@ function _mutationWithParams<Op extends AllOps>(
   type _UseMutation = {
     (
       pathParams?: undefined | null,
-      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-    ): MutationReturn<Response, PathParams, RequestBody, QueryParams>
+      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+    ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData>
     (
       pathParams: PathParamsInput | Ref<PathParamsInput> | ComputedRef<PathParamsInput>,
-      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-    ): MutationReturn<Response, PathParams, RequestBody, QueryParams>
+      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+    ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData>
     <F extends () => PathParamsInput>(
       pathParams: NoExcessReturn<PathParamsInput, F>,
-      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-    ): MutationReturn<Response, PathParams, RequestBody, QueryParams>
+      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+    ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData>
   }
 
   const _impl = (
     pathParams: ReactiveOr<PathParamsInput> | undefined | null,
-    options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-  ): MutationReturn<Response, PathParams, RequestBody, QueryParams> =>
-    useEndpointMutation<Response, PathParams, RequestBody, QueryParams>(
+    options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+  ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData> =>
+    useEndpointMutation<Response, PathParams, RequestBody, QueryParams, ErrorData>(
       { ...base, ...cfg },
       pathParams as _PathParamsCast,
       options,
@@ -1271,7 +1284,7 @@ function _mutationWithParams<Op extends AllOps>(
       const query = isQuery(id)
       const withParams = hasPathParams(id)
 
-      const cfg = `{ path: '${apiPath}', method: HttpMethod.${method}, listPath: ${listPathStr} }`
+      const cfg = `{ path: '${apiPath}', method: HttpMethod.${method}, listPath: ${listPathStr}, operationId: '${id}' }`
       const helper = query
         ? withParams
           ? '_queryWithParams'
@@ -1349,6 +1362,7 @@ import type {
   ApiPathParams,
   ApiPathParamsInput,
   ApiQueryParams,
+  ApiErrorData,
   operations,
 } from './api-operations.js'
 
@@ -1728,7 +1742,11 @@ export type ApiPathParams<K extends AllOps> = _ApiPathParams<operations, K>
 /** Path parameters input type (allows undefined values for reactive resolution). */
 export type ApiPathParamsInput<K extends AllOps> = _ApiPathParamsInput<operations, K>
 /** Query parameters type. */
-export type ApiQueryParams<K extends AllOps> = _ApiQueryParams<operations, K>`
+export type ApiQueryParams<K extends AllOps> = _ApiQueryParams<operations, K>
+/** Error data type (union of JSON bodies from 4xx / 5xx / default responses). */
+export type ApiErrorData<K extends AllOps> = _ApiErrorData<operations, K>
+/** AxiosError typed to this operation's error body. */
+export type ApiError<K extends AllOps> = _ApiErrorOf<operations, K>`
 
   // Re-exports
   // Use type-only wildcard export to avoid duplicate identifier errors
@@ -1749,6 +1767,8 @@ import type {
   ApiPathParams as _ApiPathParams,
   ApiPathParamsInput as _ApiPathParamsInput,
   ApiQueryParams as _ApiQueryParams,
+  ApiErrorData as _ApiErrorData,
+  ApiErrorOf as _ApiErrorOf,
 } from '@qualisero/openapi-endpoint'
 
 export type { operations }

--- a/src/error-policy.ts
+++ b/src/error-policy.ts
@@ -1,0 +1,144 @@
+import { toValue } from 'vue'
+import { QueryCache, MutationCache } from '@tanstack/query-core'
+import { isAxiosError, type AxiosError } from 'axios'
+
+import type { EndpointConfig, ApiErrorContext, ApiErrorPolicy, ApiErrorPolicyOptions } from './types'
+
+/**
+ * Meta key written by `stampErrorPolicyMeta` and read by the caches created
+ * via `createApiErrorCaches`. One file owns the wire format so hooks and caches
+ * cannot drift independently.
+ */
+export const ERROR_POLICY_META_KEY = '__openapiEndpoint'
+
+/**
+ * Wire format stored under `ERROR_POLICY_META_KEY` in TanStack query/mutation
+ * meta. Internal — do not depend on the shape outside this file.
+ */
+interface ErrorPolicyStamp {
+  ctx: ApiErrorContext
+  skipGlobalError?: boolean | ((error: AxiosError<unknown>) => boolean)
+}
+
+/**
+ * Strip `skipGlobalError` from caller options and merge an identity stamp into
+ * `meta`. Returns `rest` (options without `skipGlobalError`) and the merged
+ * `meta` object to spread into the TanStack hook call.
+ *
+ * Merges rather than clobbers a caller-supplied `meta`: existing keys survive.
+ * The `meta` field may be reactive inside `QueryOptions`/`MutationOptions`
+ * (wrapped by `MaybeRefDeep`); it is typed as `unknown` here so that both
+ * reactive and plain forms are accepted. The merged output is always a plain
+ * `Record<string, unknown>` — TanStack reads it synchronously in cache hooks.
+ *
+ * @internal Called by hooks only — not part of the public API surface.
+ */
+export function stampErrorPolicyMeta<
+  T extends {
+    // meta is `unknown` here because QueryOptions/MutationOptions wrap it in
+    // MaybeRefDeep, producing reactive variants that are not assignable to
+    // `Record<string, unknown>`. We cast to plain Record in the body.
+    meta?: unknown
+    // skipGlobalError is `unknown` here (not the specific predicate type) because
+    // when TError is narrower than `unknown`, the predicate parameter is narrowed
+    // too (e.g. AxiosError<string>), and under strictFunctionTypes that narrowed
+    // function type is not assignable to (error: AxiosError<unknown>) => boolean.
+    // We cast to the concrete type in the body before storing in ErrorPolicyStamp.
+    skipGlobalError?: unknown
+  },
+>(
+  options: T | undefined,
+  config: EndpointConfig,
+  kind: 'query' | 'mutation',
+): { rest: Omit<T, 'skipGlobalError'>; meta: Record<string, unknown> } {
+  const { skipGlobalError, ...rest } = (options ?? {}) as T & {
+    skipGlobalError?: boolean | ((error: AxiosError<unknown>) => boolean)
+  }
+
+  const ctx: ApiErrorContext = {
+    operationId: config.operationId ?? `${config.method} ${config.path}`,
+    path: config.path,
+    method: config.method,
+    kind,
+  }
+
+  const stamp: ErrorPolicyStamp = { ctx }
+  if (skipGlobalError !== undefined) {
+    stamp.skipGlobalError = skipGlobalError
+  }
+
+  // toValue() unwraps any Ref-valued meta before spreading; without it a
+  // caller passing meta: ref({…}) would have the ref's internals ({__v_isRef,
+  // _value, …}) spread into the merged object instead of the resolved value.
+  const callerMeta = toValue(options?.meta) as Record<string, unknown> | undefined
+  const meta: Record<string, unknown> = {
+    ...callerMeta,
+    [ERROR_POLICY_META_KEY]: stamp,
+  }
+
+  return { rest: rest as Omit<T, 'skipGlobalError'>, meta }
+}
+
+/**
+ * Create a `QueryCache` and `MutationCache` pre-wired with the library's error
+ * policy. Pass them to your `QueryClient` constructor:
+ *
+ * ```ts
+ * const { queryCache, mutationCache } = createApiErrorCaches({
+ *   onError(error, ctx) {
+ *     // observe-only: the promise always rejects afterwards.
+ *     showErrorBanner(ctx.operationId)
+ *   }
+ * })
+ * const queryClient = new QueryClient({ queryCache, mutationCache })
+ * ```
+ *
+ * **Observe-only.** `opts.onError` is a side-effect hook — the promise always
+ * rejects regardless of what the callback does or returns.
+ *
+ * **`error` is `unknown`, not `AxiosError`**, because cache-level `onError`
+ * fires for ANY rejection, including non-axios throws (e.g. errors synthesised
+ * by request interceptors). Narrow with `isAxiosError` inside the policy.
+ *
+ * **The returned caches own `config.onError`.** A consumer that needs an
+ * additional cache-level `onError` must compose it inside `opts.onError`, not
+ * replace the caches.
+ *
+ * @param opts - Policy options including the `onError` callback.
+ */
+export function createApiErrorCaches(opts: ApiErrorPolicyOptions): {
+  queryCache: QueryCache
+  mutationCache: MutationCache
+} {
+  const onError: ApiErrorPolicy | undefined = opts.onError
+
+  function handleError(error: unknown, stamp: ErrorPolicyStamp | undefined): void {
+    if (!stamp) return
+
+    const { skipGlobalError, ctx } = stamp
+
+    if (skipGlobalError === true) return
+
+    if (typeof skipGlobalError === 'function') {
+      if (isAxiosError(error) && skipGlobalError(error as AxiosError<unknown>)) return
+    }
+
+    onError?.(error, ctx)
+  }
+
+  const queryCache = new QueryCache({
+    onError(error: unknown, query: { meta?: Record<string, unknown> }) {
+      const stamp = query.meta?.[ERROR_POLICY_META_KEY] as ErrorPolicyStamp | undefined
+      handleError(error, stamp)
+    },
+  })
+
+  const mutationCache = new MutationCache({
+    onError(error: unknown, _variables: unknown, _context: unknown, mutation: { meta?: Record<string, unknown> }) {
+      const stamp = mutation.meta?.[ERROR_POLICY_META_KEY] as ErrorPolicyStamp | undefined
+      handleError(error, stamp)
+    },
+  })
+
+  return { queryCache, mutationCache }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 export { useEndpointQuery, useEndpointLazyQuery } from './openapi-query'
 export { useEndpointMutation } from './openapi-mutation'
 export { defaultQueryClient } from './openapi-helpers'
+export { createApiErrorCaches, ERROR_POLICY_META_KEY } from './error-policy'
 
 // ============================================================================
 // Return types (used in component / composable signatures)
@@ -47,7 +48,14 @@ export type {
   ApiPathParams,
   ApiPathParamsInput,
   ApiQueryParams,
+  ApiErrorOf,
+  ApiErrorData,
 } from './types'
+
+// ============================================================================
+// Error policy types
+// ============================================================================
+export type { ApiErrorContext, ApiErrorPolicy, ApiErrorPolicyOptions } from './types'
 
 // ============================================================================
 // HTTP method utilities

--- a/src/openapi-mutation.ts
+++ b/src/openapi-mutation.ts
@@ -1,7 +1,7 @@
 import { computed, ref, toValue, type ComputedRef, type Ref } from 'vue'
 import type { MaybeRefOrGetter } from '@vue/reactivity'
 import { useMutation } from '@tanstack/vue-query'
-import { type AxiosResponse } from 'axios'
+import { type AxiosError, type AxiosResponse } from 'axios'
 
 import {
   type EndpointConfig,
@@ -19,6 +19,7 @@ import {
   resolvePath,
   generateQueryKey,
 } from './openapi-utils'
+import { stampErrorPolicyMeta } from './error-policy'
 
 /**
  * Return type of `useEndpointMutation` (the `useMutation` composable on a generated namespace).
@@ -35,11 +36,12 @@ export interface MutationReturn<
   TPathParams extends Record<string, unknown> = Record<string, never>,
   TRequest = never,
   TQueryParams extends Record<string, unknown> = Record<string, never>,
+  TError = unknown,
 > {
   /** The Axios response (undefined until mutation completes). */
   data: ComputedRef<AxiosResponse<TResponse> | undefined>
   /** The error if the mutation failed. */
-  error: Ref<Error | null>
+  error: Ref<AxiosError<TError> | null>
   /** True while the mutation is in progress. */
   isPending: Ref<boolean>
   /** True when the mutation succeeded. */
@@ -80,11 +82,12 @@ export function useEndpointMutation<
   TPathParams extends Record<string, unknown> = Record<string, never>,
   TRequest = never,
   TQueryParams extends Record<string, unknown> = Record<string, never>,
+  TError = unknown,
 >(
   config: EndpointConfig,
   pathParams?: MaybeRefOrGetter<Record<string, string | number | undefined> | null | undefined>,
-  options?: MutationOptions<TResponse, TPathParams, TRequest, TQueryParams>,
-): MutationReturn<TResponse, TPathParams, TRequest, TQueryParams> {
+  options?: MutationOptions<TResponse, TPathParams, TRequest, TQueryParams, TError>,
+): MutationReturn<TResponse, TPathParams, TRequest, TQueryParams, TError> {
   if (!isMutationMethod(config.method)) {
     throw new Error(
       `Operation at '${config.path}' uses method ${config.method} and cannot be used with useMutation(). ` +
@@ -94,8 +97,10 @@ export function useEndpointMutation<
 
   const { pathParams: resolvedPathParamsInput, options: resolvedOptions } = normalizeParamsOptions<
     Record<string, string | number | undefined>,
-    MutationOptions<TResponse, TPathParams, TRequest, TQueryParams>
+    MutationOptions<TResponse, TPathParams, TRequest, TQueryParams, TError>
   >(pathParams, options)
+
+  const { rest: resolvedOptionsWithoutSkip, meta } = stampErrorPolicyMeta(resolvedOptions, config, 'mutation')
 
   const {
     axiosOptions,
@@ -105,8 +110,9 @@ export function useEndpointMutation<
     refetchEndpoints,
     queryParams,
     serialize,
+    meta: _callerMeta,
     ...useMutationOptions
-  } = resolvedOptions
+  } = resolvedOptionsWithoutSkip
 
   const extraPathParams = ref({}) as Ref<Record<string, string | undefined>>
 
@@ -293,6 +299,7 @@ export function useEndpointMutation<
         extraPathParams.value = {}
       },
       ...(serializeScope && { scope: serializeScope }),
+      meta,
       ...useMutationOptions,
     },
     config.queryClient,
@@ -304,5 +311,5 @@ export function useEndpointMutation<
     isEnabled: computed(() => isPathResolved(resolvedPath.value)),
     extraPathParams: extraPathParams as Ref<TPathParams>,
     pathParams: allPathParams as ComputedRef<TPathParams>,
-  } as unknown as MutationReturn<TResponse, TPathParams, TRequest, TQueryParams>
+  } as unknown as MutationReturn<TResponse, TPathParams, TRequest, TQueryParams, TError>
 }

--- a/src/openapi-query.ts
+++ b/src/openapi-query.ts
@@ -11,6 +11,20 @@ import {
   isQueryMethod,
 } from './types'
 import { normalizeParamsOptions, useResolvedOperation, generateQueryKey } from './openapi-utils'
+import { stampErrorPolicyMeta } from './error-policy'
+
+/**
+ * No-retry policy for 4xx HTTP errors. Extracted so both `useEndpointQuery`
+ * and the lazy `fetch()` call share identical retry behaviour.
+ *
+ * @internal
+ */
+function no4xxRetry(_failureCount: number, error: Error): boolean {
+  if (isAxiosError(error) && error.response && error.response.status >= 400 && error.response.status < 500) {
+    return false
+  }
+  return _failureCount < 3
+}
 
 /**
  * Private helper: build the query function for useEndpointQuery and useEndpointLazyQuery.
@@ -60,7 +74,11 @@ function buildQueryFn<TResponse>(
       if (errorHandler && isAxiosError(error)) {
         const result = await errorHandler(error)
         if (result !== undefined) return result
-        return undefined as unknown as TResponse
+        // TanStack Query v5 throws when a query function returns `undefined`.
+        // Returning null preserves the "swallow" semantics (the query resolves
+        // without data) while satisfying TanStack's non-undefined requirement.
+        // @deprecated path — callers should migrate to createApiErrorCaches.
+        return null as unknown as TResponse
       }
       throw error
     }
@@ -80,8 +98,12 @@ function buildQueryFn<TResponse>(
  *
  * @group Types
  */
-export type QueryReturn<TResponse, TPathParams extends Record<string, unknown> = Record<string, never>> = Omit<
-  UseQueryReturnType<TResponse, Error>,
+export type QueryReturn<
+  TResponse,
+  TPathParams extends Record<string, unknown> = Record<string, never>,
+  TError = unknown,
+> = Omit<
+  UseQueryReturnType<TResponse, AxiosError<TError>>,
   // `data` is replaced with a ComputedRef typed to TResponse | undefined.
   // `isEnabled` is replaced with our own computed that also gates on path-param resolution
   // (TanStack's isEnabled only tracks the `enabled` option flag).
@@ -118,8 +140,9 @@ export type LazyQueryReturn<
   TResponse,
   TPathParams extends Record<string, unknown> = Record<string, never>,
   TQueryParams extends Record<string, unknown> = Record<string, never>,
+  TError = unknown,
 > = Pick<
-  QueryReturn<TResponse, TPathParams>,
+  QueryReturn<TResponse, TPathParams, TError>,
   'data' | 'isPending' | 'isSuccess' | 'isError' | 'error' | 'isEnabled' | 'pathParams' | 'queryKey' | 'responseHeaders'
 > & {
   /**
@@ -154,11 +177,12 @@ export function useEndpointQuery<
   TResponse,
   TPathParams extends Record<string, unknown> = Record<string, never>,
   TQueryParams extends Record<string, unknown> = Record<string, never>,
+  TError = unknown,
 >(
   config: EndpointConfig,
   pathParams?: MaybeRefOrGetter<Record<string, string | number | undefined> | null | undefined>,
-  options?: QueryOptions<TResponse, TQueryParams>,
-): QueryReturn<TResponse, TPathParams> {
+  options?: QueryOptions<TResponse, TQueryParams, TError>,
+): QueryReturn<TResponse, TPathParams, TError> {
   if (!isQueryMethod(config.method)) {
     throw new Error(
       `Operation at '${config.path}' uses method ${config.method} and cannot be used with useQuery(). ` +
@@ -168,8 +192,10 @@ export function useEndpointQuery<
 
   const { pathParams: resolvedPathParamsInput, options: resolvedOptions } = normalizeParamsOptions<
     Record<string, string | number | undefined>,
-    QueryOptions<TResponse, TQueryParams>
+    QueryOptions<TResponse, TQueryParams, TError>
   >(pathParams, options)
+
+  const { rest: resolvedOptionsWithoutSkip, meta } = stampErrorPolicyMeta(resolvedOptions, config, 'query')
 
   const {
     enabled: enabledInit,
@@ -177,8 +203,9 @@ export function useEndpointQuery<
     axiosOptions,
     errorHandler,
     queryParams,
+    meta: _callerMeta,
     ...useQueryOptions
-  } = resolvedOptions
+  } = resolvedOptionsWithoutSkip
 
   const {
     resolvedPath,
@@ -208,12 +235,8 @@ export function useEndpointQuery<
     ),
     enabled: isEnabled,
     staleTime: 1000 * 60,
-    retry: (_failureCount: number, error: Error) => {
-      if (isAxiosError(error) && error.response && error.response.status >= 400 && error.response.status < 500) {
-        return false
-      }
-      return _failureCount < 3
-    },
+    retry: no4xxRetry,
+    meta,
     ...useQueryOptions,
   } as unknown as Parameters<typeof useQuery>[0]
 
@@ -251,7 +274,7 @@ export function useEndpointQuery<
     onLoad,
     pathParams: resolvedPathParams as ComputedRef<TPathParams>,
     responseHeaders,
-  } as unknown as QueryReturn<TResponse, TPathParams>
+  } as unknown as QueryReturn<TResponse, TPathParams, TError>
 }
 
 /**
@@ -276,11 +299,12 @@ export function useEndpointLazyQuery<
   TResponse,
   TPathParams extends Record<string, unknown> = Record<string, never>,
   TQueryParams extends Record<string, unknown> = Record<string, never>,
+  TError = unknown,
 >(
   config: EndpointConfig,
   pathParams?: MaybeRefOrGetter<Record<string, string | number | undefined> | null | undefined>,
-  options?: Omit<QueryOptions<TResponse, TQueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-): LazyQueryReturn<TResponse, TPathParams, TQueryParams> {
+  options?: Omit<QueryOptions<TResponse, TQueryParams, TError>, 'queryParams' | 'onLoad' | 'enabled'>,
+): LazyQueryReturn<TResponse, TPathParams, TQueryParams, TError> {
   if (!isQueryMethod(config.method)) {
     throw new Error(
       `Operation at '${config.path}' uses method ${config.method} and cannot be used with useLazyQuery(). ` +
@@ -290,12 +314,19 @@ export function useEndpointLazyQuery<
 
   const { pathParams: resolvedPathParamsInput } = normalizeParamsOptions<
     Record<string, string | number | undefined>,
-    Omit<QueryOptions<TResponse, TQueryParams>, 'queryParams' | 'onLoad' | 'enabled'>
+    Omit<QueryOptions<TResponse, TQueryParams, TError>, 'queryParams' | 'onLoad' | 'enabled'>
   >(pathParams, options)
 
-  const { axiosOptions, errorHandler, ...useQueryOptions } = (options || {}) as Omit<
-    QueryOptions<TResponse, TQueryParams>,
-    'queryParams' | 'onLoad' | 'enabled'
+  const { rest: optionsWithoutSkip, meta } = stampErrorPolicyMeta(options, config, 'query')
+
+  const {
+    axiosOptions,
+    errorHandler,
+    meta: _callerMetaLazy,
+    ...useQueryOptions
+  } = (optionsWithoutSkip || {}) as Omit<
+    QueryOptions<TResponse, TQueryParams, TError>,
+    'queryParams' | 'onLoad' | 'enabled' | 'skipGlobalError'
   >
 
   // Use shared path/key resolution
@@ -310,8 +341,12 @@ export function useEndpointLazyQuery<
     undefined, // no queryParams at hook level for lazy queries
   )
 
-  // Underlying query for reactive state only — never auto-fires
-  const query = useEndpointQuery<TResponse, TPathParams, TQueryParams>(config, pathParams, {
+  // Underlying query for reactive state only — never auto-fires.
+  // Pass the full `options` (not `optionsWithoutSkip`) so the inner hook's
+  // stampErrorPolicyMeta call also includes `skipGlobalError`, making both
+  // stamps identical and removing the ordering dependency on fetchQuery being
+  // the last writer of meta.
+  const query = useEndpointQuery<TResponse, TPathParams, TQueryParams, TError>(config, pathParams, {
     ...options,
     enabled: false,
     staleTime: useQueryOptions?.staleTime ?? Infinity,
@@ -344,6 +379,8 @@ export function useEndpointLazyQuery<
         responseHeaders,
       ),
       staleTime: useQueryOptions?.staleTime ?? Infinity,
+      retry: no4xxRetry,
+      meta,
     })
   }
 

--- a/src/openapi-query.ts
+++ b/src/openapi-query.ts
@@ -88,7 +88,7 @@ function buildQueryFn<TResponse>(
 /**
  * Return type of `useEndpointQuery` (the `useQuery` composable on a generated namespace).
  *
- * Extends TanStack's `UseQueryReturnType<TResponse, Error>` so all fields — including
+ * Extends TanStack's `UseQueryReturnType<TResponse, AxiosError<TError>>` so all fields — including
  * `refetch`, `isPending`, `isLoading`, `isSuccess`, `isError`, `error`, etc. — carry
  * their real TanStack types. `data` is overridden with a `ComputedRef` typed to
  * `TResponse | undefined`, and three extra fields are added for our own abstractions.

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,47 @@ export interface EndpointConfig {
    * option at mutation time. Generated and embedded by the CLI.
    */
   operationsRegistry?: Readonly<Record<string, { path: string }>>
+  /**
+   * The OpenAPI `operationId` for this operation. Provided by generated code;
+   * used to populate `ApiErrorContext.operationId` in the error policy.
+   * When absent, the policy falls back to `"METHOD /path/template"`.
+   */
+  operationId?: string
+}
+
+// ============================================================================
+// Error policy types
+// ============================================================================
+
+/**
+ * Context passed to the global `onError` policy callback. Identifies which
+ * operation failed so the policy can log, display, or filter by operation.
+ */
+export interface ApiErrorContext {
+  /** The OpenAPI `operationId`, or `"METHOD /path/template"` when not set. */
+  operationId: string
+  /** The OpenAPI path template, e.g. `'/pets/{petId}'`. */
+  path: string
+  /** HTTP method of the operation. */
+  method: HttpMethod
+  /** Whether the failure came from a query or a mutation. */
+  kind: 'query' | 'mutation'
+}
+
+/**
+ * Global error side-effect callback. Observe-only — the promise always rejects
+ * after this returns. `error` is `unknown` (not `AxiosError`) because the
+ * cache-level hook fires for ANY rejection, including non-axios throws.
+ * Narrow with `isAxiosError` inside the policy if needed.
+ */
+export type ApiErrorPolicy = (error: unknown, ctx: ApiErrorContext) => void
+
+/**
+ * Options for `createApiErrorCaches`.
+ */
+export interface ApiErrorPolicyOptions {
+  /** Called once per logical failure, after retries, without swallowing the rejection. */
+  onError?: ApiErrorPolicy
 }
 
 // ============================================================================
@@ -149,8 +190,8 @@ type MaybeRefDeep<T> = T extends (...args: never[]) => unknown
     ? { [K in keyof T]: MaybeRefDeep<T[K]> }
     : MaybeRefLeaf<T>
 
-type BaseQueryOptions<TResponse, _TQueryParams extends Record<string, unknown>> = MaybeRefDeep<
-  QueryObserverOptions<TResponse, Error, TResponse, TResponse, QueryKey>
+type BaseQueryOptions<TResponse, _TQueryParams extends Record<string, unknown>, TError = unknown> = MaybeRefDeep<
+  QueryObserverOptions<TResponse, AxiosError<TError>, TResponse, TResponse, QueryKey>
 > & { shallow?: boolean }
 
 /**
@@ -164,14 +205,34 @@ type BaseQueryOptions<TResponse, _TQueryParams extends Record<string, unknown>> 
  * @template TResponse    The response data type for this operation
  * @template TQueryParams The query parameters type for this operation
  */
-export type QueryOptions<TResponse, TQueryParams extends Record<string, unknown> = Record<string, never>> = Omit<
-  BaseQueryOptions<TResponse, TQueryParams>,
-  'queryKey' | 'queryFn' | 'enabled'
-> & {
+export type QueryOptions<
+  TResponse,
+  TQueryParams extends Record<string, unknown> = Record<string, never>,
+  TError = unknown,
+> = Omit<BaseQueryOptions<TResponse, TQueryParams, TError>, 'queryKey' | 'queryFn' | 'enabled'> & {
   enabled?: ReactiveOr<boolean>
   onLoad?: (data: TResponse) => void
   axiosOptions?: AxiosRequestConfigExtended
+  /**
+   * @deprecated Use the `onError` policy on `createApiErrorCaches` instead.
+   * `errorHandler` swallows the error unless it rethrows, fires per retry
+   * attempt, and only receives `AxiosError` (non-axios throws bypass it).
+   * The cache-level `onError` policy fires once, after retries, and receives
+   * any rejection.
+   */
   errorHandler?: (error: AxiosError) => TResponse | void | Promise<TResponse | void>
+  /**
+   * Suppress the client-level `onError` policy for this call.
+   * `true` → always suppress; function → suppress when it returns `true`
+   * (e.g. only on 409). The promise rejects either way; this controls the
+   * global side-effect only.
+   *
+   * Note: a non-axios throw also reaches the predicate. Documented, not hidden.
+   *
+   * The predicate parameter is narrowed to `AxiosError<TError>` when `TError`
+   * is supplied. With the default `TError = unknown` it is `AxiosError<unknown>`.
+   */
+  skipGlobalError?: boolean | ((error: AxiosError<TError>) => boolean)
   queryParams?: ReactiveOr<TQueryParams>
 }
 
@@ -222,8 +283,14 @@ type BaseMutationOptions<
   TPathParams extends Record<string, unknown>,
   TRequest,
   TQueryParams extends Record<string, unknown>,
+  TError = unknown,
 > = MaybeRefDeep<
-  MutationObserverOptions<AxiosResponse<TResponse>, Error, MutationVars<TPathParams, TRequest, TQueryParams>, unknown>
+  MutationObserverOptions<
+    AxiosResponse<TResponse>,
+    AxiosError<TError>,
+    MutationVars<TPathParams, TRequest, TQueryParams>,
+    unknown
+  >
 > & { shallow?: boolean }
 
 /**
@@ -239,7 +306,8 @@ export type MutationOptions<
   TPathParams extends Record<string, unknown>,
   TRequest,
   TQueryParams extends Record<string, unknown> = Record<string, never>,
-> = Omit<BaseMutationOptions<TResponse, TPathParams, TRequest, TQueryParams>, 'mutationFn' | 'mutationKey'> &
+  TError = unknown,
+> = Omit<BaseMutationOptions<TResponse, TPathParams, TRequest, TQueryParams, TError>, 'mutationFn' | 'mutationKey'> &
   CacheInvalidationOptions & {
     axiosOptions?: AxiosRequestConfigExtended
     queryParams?: ReactiveOr<TQueryParams>
@@ -258,6 +326,18 @@ export type MutationOptions<
      * `serialize`. A warning is emitted when both are set.
      */
     serialize?: boolean | string
+    /**
+     * Suppress the client-level `onError` policy for this call.
+     * `true` → always suppress; function → suppress when it returns `true`
+     * (e.g. only on 409). The promise rejects either way; this controls the
+     * global side-effect only.
+     *
+     * Note: a non-axios throw also reaches the predicate. Documented, not hidden.
+     *
+     * The predicate parameter is narrowed to `AxiosError<TError>` when `TError`
+     * is supplied. With the default `TError = unknown` it is `AxiosError<unknown>`.
+     */
+    skipGlobalError?: boolean | ((error: AxiosError<TError>) => boolean)
   }
 
 // ============================================================================
@@ -334,6 +414,84 @@ type ExtractResponseData<Ops extends AnyOps, Op extends keyof Ops> = Ops[Op] ext
           : Ops[Op] extends { responses: { 206: { content: { 'application/json': infer Data } } } }
             ? Data
             : unknown
+
+// ============================================================================
+// Error response type extraction
+// ============================================================================
+
+/**
+ * Keys in an OpenAPI `responses` object that denote error responses:
+ * the string `'default'`, range keys `'4XX'` / `'5XX'`, and numeric
+ * 4xx / 5xx status codes.
+ *
+ * Numeric range detection uses a template-literal `${S}` trick because
+ * numeric literal types are not directly pattern-matchable. A third arm
+ * also accepts quoted numeric string keys (e.g. '404') by checking the
+ * string prefix directly ('4...' or '5...').
+ *
+ * @internal
+ */
+type ErrorStatusKey<S> = S extends 'default' | '4XX' | '5XX'
+  ? S
+  : S extends number
+    ? `${S}` extends `4${string}` | `5${string}`
+      ? S
+      : never
+    : S extends `4${string}` | `5${string}`
+      ? S
+      : never
+
+/**
+ * Extract the union of JSON body types declared for error responses
+ * (4xx, 5xx, `default`, `4XX`, `5XX`) of operation `Op`.
+ *
+ * Falls back to `unknown` when no error response declares a JSON body —
+ * so `error.response.data` is always at least `unknown`, never `never`.
+ *
+ * @internal
+ */
+type ExtractErrorData<Ops extends AnyOps, Op extends keyof Ops> = Ops[Op] extends { responses: infer R }
+  ? {
+      [S in keyof R as ErrorStatusKey<S>]: R[S] extends { content: { 'application/json': infer D } } ? D : never
+    } extends infer M extends Record<PropertyKey, unknown>
+    ? M[keyof M] extends infer U
+      ? [U] extends [never]
+        ? unknown
+        : U
+      : unknown
+    : unknown
+  : unknown
+
+/**
+ * The `AxiosError` type for operation `Op`, with its `response.data` typed to
+ * the union of JSON bodies declared for all error responses (4xx / 5xx /
+ * `default`). Falls back to `AxiosError<unknown>` for operations that declare
+ * no JSON error body.
+ *
+ * @example
+ * ```ts
+ * // Assuming operations.createVessel has a 422 response with JSON body:
+ * type E = ApiErrorOf<operations, 'createVessel'>
+ * // → AxiosError<{ code?: string; message?: string }>
+ * ```
+ */
+export type ApiErrorOf<Ops extends AnyOps, Op extends keyof Ops> = AxiosError<ExtractErrorData<Ops, Op>>
+
+/**
+ * Extract the union of JSON body types declared for error responses.
+ * Equivalent to the `response.data` type of `ApiErrorOf<Ops, Op>`.
+ *
+ * Use this when you need the raw error payload type (not wrapped in `AxiosError`).
+ *
+ * @example
+ * ```ts
+ * type E = ApiErrorData<operations, 'createVessel'>
+ * // → { code?: string; message?: string } | undefined
+ * ```
+ */
+export type ApiErrorData<Ops extends AnyOps, Op extends keyof Ops> = ExtractErrorData<Ops, Op>
+
+// ============================================================================
 
 /**
  * Extract response data type (ALL fields required - default behavior).

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,7 +227,9 @@ export type QueryOptions<
    * (e.g. only on 409). The promise rejects either way; this controls the
    * global side-effect only.
    *
-   * Note: a non-axios throw also reaches the predicate. Documented, not hidden.
+   * Note: the predicate is only evaluated for axios errors. A non-axios throw
+   * (e.g. synthesised by a request interceptor) cannot be selectively
+   * suppressed; use `skipGlobalError: true` to always suppress.
    *
    * The predicate parameter is narrowed to `AxiosError<TError>` when `TError`
    * is supplied. With the default `TError = unknown` it is `AxiosError<unknown>`.
@@ -332,7 +334,9 @@ export type MutationOptions<
      * (e.g. only on 409). The promise rejects either way; this controls the
      * global side-effect only.
      *
-     * Note: a non-axios throw also reaches the predicate. Documented, not hidden.
+     * Note: the predicate is only evaluated for axios errors. A non-axios throw
+     * (e.g. synthesised by a request interceptor) cannot be selectively
+     * suppressed; use `skipGlobalError: true` to always suppress.
      *
      * The predicate parameter is narrowed to `AxiosError<TError>` when `TError`
      * is supplied. With the default `TError = unknown` it is `AxiosError<unknown>`.
@@ -486,7 +490,9 @@ export type ApiErrorOf<Ops extends AnyOps, Op extends keyof Ops> = AxiosError<Ex
  * @example
  * ```ts
  * type E = ApiErrorData<operations, 'createVessel'>
- * // → { code?: string; message?: string } | undefined
+ * // → { code?: string; message?: string }
+ * // (`undefined` only appears via optional chaining on `error.response`,
+ * //  it is not part of `ApiErrorData` itself)
  * ```
  */
 export type ApiErrorData<Ops extends AnyOps, Op extends keyof Ops> = ExtractErrorData<Ops, Op>

--- a/tests/fixtures/api-client.ts
+++ b/tests/fixtures/api-client.ts
@@ -9,6 +9,7 @@ import {
   useEndpointLazyQuery,
   defaultQueryClient,
   HttpMethod,
+  buildUrl,
   type QueryOptions,
   type MutationOptions,
   type QueryReturn,
@@ -27,6 +28,7 @@ import type {
   ApiPathParams,
   ApiPathParamsInput,
   ApiQueryParams,
+  ApiErrorData,
   operations,
 } from './api-operations.js'
 
@@ -104,19 +106,26 @@ type AllOps = keyof operations
  */
 function _queryNoParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type Response = ApiResponse<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
-  const useQuery = (options?: QueryOptions<Response, QueryParams>): QueryReturn<Response, Record<string, never>> =>
-    useEndpointQuery<Response, Record<string, never>, QueryParams>({ ...base, ...cfg }, undefined, options)
+  const useQuery = (
+    options?: QueryOptions<Response, QueryParams, ErrorData>,
+  ): QueryReturn<Response, Record<string, never>, ErrorData> =>
+    useEndpointQuery<Response, Record<string, never>, QueryParams, ErrorData>({ ...base, ...cfg }, undefined, options)
 
   const useLazyQuery = (
-    options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-  ): LazyQueryReturn<Response, Record<string, never>, QueryParams> =>
-    useEndpointLazyQuery<Response, Record<string, never>, QueryParams>({ ...base, ...cfg }, undefined, options)
+    options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+  ): LazyQueryReturn<Response, Record<string, never>, QueryParams, ErrorData> =>
+    useEndpointLazyQuery<Response, Record<string, never>, QueryParams, ErrorData>(
+      { ...base, ...cfg },
+      undefined,
+      options,
+    )
 
   return {
     /**
@@ -149,6 +158,17 @@ function _queryNoParams<Op extends AllOps>(
      * @returns Lazy query result object
      */
     useLazyQuery,
+    /**
+     * Build a URL string for this operation without executing a fetch.
+     *
+     * Synchronous; only accepts plain values. Only flat scalar query params
+     * are supported (see `buildUrl`). The axios `baseURL` is read at call time.
+     *
+     * @param queryParams - Optional flat query parameters to append.
+     * @returns Full URL string.
+     */
+    urlFor: (queryParams?: QueryParams): string =>
+      buildUrl(base.axios.defaults.baseURL, cfg.path, undefined, queryParams),
     enums,
   } as const
 }
@@ -159,49 +179,58 @@ function _queryNoParams<Op extends AllOps>(
  */
 function _queryWithParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type PathParams = ApiPathParams<Op>
   type PathParamsInput = ApiPathParamsInput<Op>
   type Response = ApiResponse<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
   // Two-overload interface: non-function (exact via object-literal checking) +
   // getter function (exact via NoExcessReturn constraint).
   type _UseQuery = {
     (
       pathParams: PathParamsInput | Ref<PathParamsInput> | ComputedRef<PathParamsInput>,
-      options?: QueryOptions<Response, QueryParams>,
-    ): QueryReturn<Response, PathParams>
+      options?: QueryOptions<Response, QueryParams, ErrorData>,
+    ): QueryReturn<Response, PathParams, ErrorData>
     <F extends () => PathParamsInput>(
       pathParams: NoExcessReturn<PathParamsInput, F>,
-      options?: QueryOptions<Response, QueryParams>,
-    ): QueryReturn<Response, PathParams>
+      options?: QueryOptions<Response, QueryParams, ErrorData>,
+    ): QueryReturn<Response, PathParams, ErrorData>
   }
 
   type _UseLazyQuery = {
     (
       pathParams: PathParamsInput | Ref<PathParamsInput> | ComputedRef<PathParamsInput>,
-      options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-    ): LazyQueryReturn<Response, PathParams, QueryParams>
+      options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+    ): LazyQueryReturn<Response, PathParams, QueryParams, ErrorData>
     <F extends () => PathParamsInput>(
       pathParams: NoExcessReturn<PathParamsInput, F>,
-      options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-    ): LazyQueryReturn<Response, PathParams, QueryParams>
+      options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+    ): LazyQueryReturn<Response, PathParams, QueryParams, ErrorData>
   }
 
   const _impl = (
     pathParams: ReactiveOr<PathParamsInput>,
-    options?: QueryOptions<Response, QueryParams>,
-  ): QueryReturn<Response, PathParams> =>
-    useEndpointQuery<Response, PathParams, QueryParams>({ ...base, ...cfg }, pathParams as _PathParamsCast, options)
+    options?: QueryOptions<Response, QueryParams, ErrorData>,
+  ): QueryReturn<Response, PathParams, ErrorData> =>
+    useEndpointQuery<Response, PathParams, QueryParams, ErrorData>(
+      { ...base, ...cfg },
+      pathParams as _PathParamsCast,
+      options,
+    )
 
   const _lazyImpl = (
     pathParams: ReactiveOr<PathParamsInput>,
-    options?: Omit<QueryOptions<Response, QueryParams>, 'queryParams' | 'onLoad' | 'enabled'>,
-  ): LazyQueryReturn<Response, PathParams, QueryParams> =>
-    useEndpointLazyQuery<Response, PathParams, QueryParams>({ ...base, ...cfg }, pathParams as _PathParamsCast, options)
+    options?: Omit<QueryOptions<Response, QueryParams, ErrorData>, 'queryParams' | 'onLoad' | 'enabled'>,
+  ): LazyQueryReturn<Response, PathParams, QueryParams, ErrorData> =>
+    useEndpointLazyQuery<Response, PathParams, QueryParams, ErrorData>(
+      { ...base, ...cfg },
+      pathParams as _PathParamsCast,
+      options,
+    )
 
   return {
     /**
@@ -236,6 +265,30 @@ function _queryWithParams<Op extends AllOps>(
      * @returns Lazy query result object
      */
     useLazyQuery: _lazyImpl as _UseLazyQuery,
+    /**
+     * Build a URL string for this operation without executing a fetch.
+     *
+     * Useful when a URL is needed directly — e.g. for <img :src>, anchor hrefs,
+     * or any context where the browser/native element handles the request.
+     *
+     * Unlike `useQuery`, `urlFor` is synchronous and only accepts plain values —
+     * not refs, computed, or getter functions. Wrap in `computed(...)` for reactivity.
+     *
+     * Only flat scalar query params are supported (see `buildUrl`).
+     * The axios `baseURL` is read at call time.
+     *
+     * @param pathParams  - Path parameters to substitute into the URL template (plain object).
+     * @param queryParams - Optional flat query parameters to append.
+     * @returns Full URL string.
+     *
+     * @example
+     * const url = api.getAssetDocumentFile.urlFor(
+     *   { asset_id: assetId, document_ref: doc.document_ref },
+     *   { view: true }
+     * )
+     */
+    urlFor: (pathParams: PathParamsInput, queryParams?: QueryParams): string =>
+      buildUrl(base.axios.defaults.baseURL, cfg.path, pathParams, queryParams),
     enums,
   } as const
 }
@@ -246,17 +299,18 @@ function _queryWithParams<Op extends AllOps>(
  */
 function _mutationNoParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type RequestBody = ApiRequest<Op>
   type Response = ApiResponse<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
   const useMutation = (
-    options?: MutationOptions<Response, Record<string, never>, RequestBody, QueryParams>,
-  ): MutationReturn<Response, Record<string, never>, RequestBody, QueryParams> =>
-    useEndpointMutation<Response, Record<string, never>, RequestBody, QueryParams>(
+    options?: MutationOptions<Response, Record<string, never>, RequestBody, QueryParams, ErrorData>,
+  ): MutationReturn<Response, Record<string, never>, RequestBody, QueryParams, ErrorData> =>
+    useEndpointMutation<Response, Record<string, never>, RequestBody, QueryParams, ErrorData>(
       { ...base, ...cfg },
       undefined,
       options,
@@ -289,7 +343,7 @@ function _mutationNoParams<Op extends AllOps>(
  */
 function _mutationWithParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type PathParams = ApiPathParams<Op>
@@ -297,6 +351,7 @@ function _mutationWithParams<Op extends AllOps>(
   type RequestBody = ApiRequest<Op>
   type Response = ApiResponse<Op>
   type QueryParams = ApiQueryParams<Op>
+  type ErrorData = ApiErrorData<Op>
 
   // Three-overload interface:
   // 1. Deferred path params — omit or pass undefined/null; supply at mutateAsync() time via pathParams variable
@@ -305,23 +360,23 @@ function _mutationWithParams<Op extends AllOps>(
   type _UseMutation = {
     (
       pathParams?: undefined | null,
-      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-    ): MutationReturn<Response, PathParams, RequestBody, QueryParams>
+      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+    ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData>
     (
       pathParams: PathParamsInput | Ref<PathParamsInput> | ComputedRef<PathParamsInput>,
-      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-    ): MutationReturn<Response, PathParams, RequestBody, QueryParams>
+      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+    ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData>
     <F extends () => PathParamsInput>(
       pathParams: NoExcessReturn<PathParamsInput, F>,
-      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-    ): MutationReturn<Response, PathParams, RequestBody, QueryParams>
+      options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+    ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData>
   }
 
   const _impl = (
     pathParams: ReactiveOr<PathParamsInput> | undefined | null,
-    options?: MutationOptions<Response, PathParams, RequestBody, QueryParams>,
-  ): MutationReturn<Response, PathParams, RequestBody, QueryParams> =>
-    useEndpointMutation<Response, PathParams, RequestBody, QueryParams>(
+    options?: MutationOptions<Response, PathParams, RequestBody, QueryParams, ErrorData>,
+  ): MutationReturn<Response, PathParams, RequestBody, QueryParams, ErrorData> =>
+    useEndpointMutation<Response, PathParams, RequestBody, QueryParams, ErrorData>(
       { ...base, ...cfg },
       pathParams as _PathParamsCast,
       options,
@@ -384,7 +439,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     createPet: _mutationNoParams<'createPet'>(
       base,
-      { path: '/pets', method: HttpMethod.POST, listPath: '/pets' },
+      { path: '/pets', method: HttpMethod.POST, listPath: '/pets', operationId: 'createPet' },
       createPet_enums,
     ),
     /**
@@ -393,7 +448,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     deletePet: _mutationWithParams<'deletePet'>(
       base,
-      { path: '/pets/{petId}', method: HttpMethod.DELETE, listPath: '/pets' },
+      { path: '/pets/{petId}', method: HttpMethod.DELETE, listPath: '/pets', operationId: 'deletePet' },
       deletePet_enums,
     ),
     /**
@@ -401,7 +456,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     getConfigJson: _queryNoParams<'getConfigJson'>(
       base,
-      { path: '/api/config.json', method: HttpMethod.GET, listPath: null },
+      { path: '/api/config.json', method: HttpMethod.GET, listPath: null, operationId: 'getConfigJson' },
       getConfigJson_enums,
     ),
     /**
@@ -409,7 +464,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     getDataV1Json: _queryNoParams<'getDataV1Json'>(
       base,
-      { path: '/api/data.v1.json', method: HttpMethod.GET, listPath: null },
+      { path: '/api/data.v1.json', method: HttpMethod.GET, listPath: null, operationId: 'getDataV1Json' },
       getDataV1Json_enums,
     ),
     /**
@@ -417,7 +472,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     getOwners: _queryNoParams<'getOwners'>(
       base,
-      { path: '/owners', method: HttpMethod.GET, listPath: null },
+      { path: '/owners', method: HttpMethod.GET, listPath: null, operationId: 'getOwners' },
       getOwners_enums,
     ),
     /**
@@ -427,7 +482,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     getPet: _queryWithParams<'getPet'>(
       base,
-      { path: '/pets/{petId}', method: HttpMethod.GET, listPath: null },
+      { path: '/pets/{petId}', method: HttpMethod.GET, listPath: null, operationId: 'getPet' },
       getPet_enums,
     ),
     /**
@@ -437,7 +492,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     getPetPetId: _queryWithParams<'getPetPetId'>(
       base,
-      { path: '/api/pet/{pet_id}', method: HttpMethod.GET, listPath: null },
+      { path: '/api/pet/{pet_id}', method: HttpMethod.GET, listPath: null, operationId: 'getPetPetId' },
       getPetPetId_enums,
     ),
     /**
@@ -445,7 +500,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     listPets: _queryNoParams<'listPets'>(
       base,
-      { path: '/pets', method: HttpMethod.GET, listPath: null },
+      { path: '/pets', method: HttpMethod.GET, listPath: null, operationId: 'listPets' },
       listPets_enums,
     ),
     /**
@@ -454,7 +509,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     listUserPets: _queryWithParams<'listUserPets'>(
       base,
-      { path: '/users/{userId}/pets', method: HttpMethod.GET, listPath: null },
+      { path: '/users/{userId}/pets', method: HttpMethod.GET, listPath: null, operationId: 'listUserPets' },
       listUserPets_enums,
     ),
     /**
@@ -462,7 +517,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     postOwners: _mutationNoParams<'postOwners'>(
       base,
-      { path: '/owners', method: HttpMethod.POST, listPath: null },
+      { path: '/owners', method: HttpMethod.POST, listPath: null, operationId: 'postOwners' },
       postOwners_enums,
     ),
     /**
@@ -472,7 +527,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     postPetAdopt: _mutationWithParams<'postPetAdopt'>(
       base,
-      { path: '/api/pet/{pet_id}/adopt', method: HttpMethod.POST, listPath: null },
+      { path: '/api/pet/{pet_id}/adopt', method: HttpMethod.POST, listPath: null, operationId: 'postPetAdopt' },
       postPetAdopt_enums,
     ),
     /**
@@ -480,7 +535,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     postPetGiveTreats: _mutationNoParams<'postPetGiveTreats'>(
       base,
-      { path: '/api/pet/give_treats', method: HttpMethod.POST, listPath: null },
+      { path: '/api/pet/give_treats', method: HttpMethod.POST, listPath: null, operationId: 'postPetGiveTreats' },
       postPetGiveTreats_enums,
     ),
     /**
@@ -488,7 +543,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     searchPets: _queryNoParams<'searchPets'>(
       base,
-      { path: '/pets/search', method: HttpMethod.GET, listPath: null },
+      { path: '/pets/search', method: HttpMethod.GET, listPath: null, operationId: 'searchPets' },
       searchPets_enums,
     ),
     /**
@@ -499,7 +554,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     updatePet: _mutationWithParams<'updatePet'>(
       base,
-      { path: '/pets/{petId}', method: HttpMethod.PUT, listPath: '/pets' },
+      { path: '/pets/{petId}', method: HttpMethod.PUT, listPath: '/pets', operationId: 'updatePet' },
       updatePet_enums,
     ),
     /**
@@ -510,7 +565,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     updatePetPetId: _mutationWithParams<'updatePetPetId'>(
       base,
-      { path: '/api/pet/{pet_id}', method: HttpMethod.PATCH, listPath: '/api/pet/' },
+      { path: '/api/pet/{pet_id}', method: HttpMethod.PATCH, listPath: '/api/pet/', operationId: 'updatePetPetId' },
       updatePetPetId_enums,
     ),
     /**
@@ -520,7 +575,7 @@ export function createApiClient(axios: AxiosInstance, queryClient: QueryClient =
      */
     uploadPetPic: _mutationWithParams<'uploadPetPic'>(
       base,
-      { path: '/pets/{petId}/upload', method: HttpMethod.POST, listPath: null },
+      { path: '/pets/{petId}/upload', method: HttpMethod.POST, listPath: null, operationId: 'uploadPetPic' },
       uploadPetPic_enums,
     ),
   } as const

--- a/tests/fixtures/api-enums.ts
+++ b/tests/fixtures/api-enums.ts
@@ -50,7 +50,27 @@ export const EnumHelper = {
 } as const
 
 /**
- * Enum values from components.schemas.Pet.properties.status
+ * Enum values from components.schemas.PetPriority
+ */
+export const PetPriority = {
+  _0: '0' as const,
+  _0_1: '0.1' as const,
+  _0_2: '0.2' as const,
+  _0_5: '0.5' as const,
+  _0_7: '0.7' as const,
+  _1: '1' as const,
+  _2: '2' as const,
+  _3: '3' as const,
+} as const
+
+export type PetPriority = (typeof PetPriority)[keyof typeof PetPriority]
+
+// Type aliases for duplicate enum values
+export const ListPetsPriority = PetPriority
+export type ListPetsPriority = PetPriority
+
+/**
+ * Enum values from components.schemas.PetStatus
  */
 export const PetStatus = {
   Adopted: 'adopted' as const,

--- a/tests/fixtures/api-operations.ts
+++ b/tests/fixtures/api-operations.ts
@@ -9,10 +9,13 @@ import type {
   ApiPathParams as _ApiPathParams,
   ApiPathParamsInput as _ApiPathParamsInput,
   ApiQueryParams as _ApiQueryParams,
+  ApiErrorData as _ApiErrorData,
+  ApiErrorOf as _ApiErrorOf,
 } from '@qualisero/openapi-endpoint'
 
 export type { operations }
 
+export { PetPriority } from './api-enums'
 export { PetStatus } from './api-enums'
 export type * from './api-enums'
 
@@ -39,6 +42,16 @@ export const listPets_enums = {
     Available: 'available' as const,
     Pending: 'pending' as const,
     Adopted: 'adopted' as const,
+  } as const,
+  priority: {
+    _0: '0' as const,
+    _0_1: '0.1' as const,
+    _0_2: '0.2' as const,
+    _0_5: '0.5' as const,
+    _0_7: '0.7' as const,
+    _1: '1' as const,
+    _2: '2' as const,
+    _3: '3' as const,
   } as const,
 } as const
 
@@ -102,3 +115,7 @@ export type ApiPathParams<K extends AllOps> = _ApiPathParams<operations, K>
 export type ApiPathParamsInput<K extends AllOps> = _ApiPathParamsInput<operations, K>
 /** Query parameters type. */
 export type ApiQueryParams<K extends AllOps> = _ApiQueryParams<operations, K>
+/** Error data type (union of JSON bodies from 4xx / 5xx / default responses). */
+export type ApiErrorData<K extends AllOps> = _ApiErrorData<operations, K>
+/** AxiosError typed to this operation's error body. */
+export type ApiError<K extends AllOps> = _ApiErrorOf<operations, K>

--- a/tests/fixtures/api-schemas.ts
+++ b/tests/fixtures/api-schemas.ts
@@ -17,6 +17,4 @@ export type NewPet = components['schemas']['NewPet']
 
 export type Pet = components['schemas']['Pet']
 
-export type PetStatus = components['schemas']['PetStatus']
-
 export type SingleFile = components['schemas']['SingleFile']

--- a/tests/fixtures/api-types.ts
+++ b/tests/fixtures/api-types.ts
@@ -124,6 +124,8 @@ export namespace Types {
     export namespace Enums {
       /** `'available' | 'pending' | 'adopted'` */
       export type Status = 'available' | 'pending' | 'adopted'
+      /** `'0' | '0.1' | '0.2' | '0.5' | '0.7' | '1' | '2' | '3'` */
+      export type Priority = '0' | '0.1' | '0.2' | '0.5' | '0.7' | '1' | '2' | '3'
     }
   }
 

--- a/tests/fixtures/error-schema-openapi.json
+++ b/tests/fixtures/error-schema-openapi.json
@@ -1,0 +1,114 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Error Schema Test API",
+    "description": "A minimal API spec with a component schema named 'Error' to test the reserved-name guard",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "summary": "List all items",
+        "responses": {
+          "200": {
+            "description": "A list of items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Item"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createItem",
+        "summary": "Create a new item",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Item"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Item": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "NewItem": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/openapi-types.ts
+++ b/tests/fixtures/openapi-types.ts
@@ -202,6 +202,8 @@ export interface components {
   schemas: {
     /** @enum {string} */
     PetStatus: 'available' | 'pending' | 'adopted'
+    /** @enum {string} */
+    PetPriority: '0' | '0.1' | '0.2' | '0.5' | '0.7' | '1' | '2' | '3'
     Pet: {
       /** Format: uuid */
       readonly id?: string
@@ -232,6 +234,7 @@ export interface operations {
       query?: {
         limit?: number
         status?: components['schemas']['PetStatus']
+        priority?: components['schemas']['PetPriority']
       }
       header?: never
       path?: never

--- a/tests/typing/error-extraction.ts
+++ b/tests/typing/error-extraction.ts
@@ -1,0 +1,419 @@
+/**
+ * §3.5 typed-channel tests — error extraction (compile-time assertions).
+ *
+ * These tests never run — validated by `npm run types:test` (tsc --noEmit).
+ *
+ * Uses inline operation type literals that mirror openapi-typescript output,
+ * so these tests are self-contained and do not depend on the toy-spec fixture
+ * being regenerated (though some tests also reference fixture operations
+ * for the real-hook usage pattern).
+ *
+ * Covered cases (per plan §3.5):
+ *  1. Operation with only a `default` error response
+ *  2. 4xx declaring NO body → unknown, not never
+ *  3. Two different 4xx bodies → union
+ *  4. '4XX'/'5XX' range keys → body extracted
+ *  5. skipGlobalError narrowed predicate compiles under strict + strictFunctionTypes;
+ *     parameter is AxiosError<declared type>
+ *  6. error.value on a typed hook is AxiosError<T> | null; .response?.data is the
+ *     declared shape
+ */
+
+import type { Ref } from 'vue'
+import type { AxiosError } from 'axios'
+import type {
+  ApiErrorOf,
+  ApiErrorData,
+  QueryReturn,
+  LazyQueryReturn,
+  MutationReturn,
+  QueryOptions,
+  MutationOptions,
+} from '@qualisero/openapi-endpoint'
+
+/**
+ * Mutual-identity equality check. True only when A and B are the exact same type
+ * (i.e. mutually assignable). Unlike `A extends B ? true : false`, this catches
+ * the `never` case — `never extends unknown` is vacuously true, but
+ * `Eq<never, unknown>` is false.
+ */
+type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+import { createApiClient } from '../fixtures/api-client.js'
+import { mockAxios } from '../setup.js'
+import type { operations } from '../fixtures/openapi-types.js'
+
+// ============================================================================
+// Case 1 — Operation with only a `default` error response
+//
+// openapi-typescript output shape: operations['myOp'].responses.default = { content: ... }
+// ============================================================================
+
+/** Inline operation type literal mirroring openapi-typescript output. */
+type OpsDefaultOnly = {
+  readonly listThings: {
+    readonly parameters: { query?: never; header?: never; path?: never; cookie?: never }
+    readonly responses: {
+      /** @description Success */
+      readonly 200: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: { readonly 'application/json': { readonly items: string[] } }
+      }
+      /** @description Unexpected error */
+      readonly default: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: {
+          readonly 'application/json': { readonly code: string; readonly message: string }
+        }
+      }
+    }
+  }
+}
+
+type Case1ErrorData = ApiErrorData<OpsDefaultOnly, 'listThings'>
+type Case1Error = ApiErrorOf<OpsDefaultOnly, 'listThings'>
+
+// Error data should be the default body, not unknown
+type _C1a = Case1ErrorData extends { code: string; message: string } ? true : false
+const _c1a: _C1a = true
+
+// ApiErrorOf wraps it in AxiosError
+type _C1b = Case1Error extends AxiosError<{ code: string; message: string }> ? true : false
+const _c1b: _C1b = true
+
+// ============================================================================
+// Case 2 — 4xx declaring NO body → unknown, not never
+//
+// Description-only 4xx responses have no `content` key in openapi-typescript output.
+// ============================================================================
+
+type OpsNoBody = {
+  readonly getItem: {
+    readonly parameters: {
+      query?: never
+      header?: never
+      path: { readonly itemId: number }
+      cookie?: never
+    }
+    readonly responses: {
+      readonly 200: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: { readonly 'application/json': { readonly id: number; readonly name: string } }
+      }
+      /** @description Not found — description-only, no JSON body */
+      readonly 404: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content?: never
+      }
+      /** @description Forbidden */
+      readonly 403: {
+        readonly headers: { readonly [name: string]: unknown }
+        // no content property at all
+      }
+    }
+  }
+}
+
+type Case2ErrorData = ApiErrorData<OpsNoBody, 'getItem'>
+type Case2Error = ApiErrorOf<OpsNoBody, 'getItem'>
+
+// Must be EXACTLY unknown (not never) when no JSON body declared.
+// Eq<A,B> requires mutual assignability; 'never extends unknown' is vacuously true,
+// so the one-directional form would pass even if the extractor returned never.
+type _C2a = Eq<Case2ErrorData, unknown>
+const _c2a: _C2a = true
+
+// AxiosError<unknown>, not AxiosError<never> — verify the data type is not `never`
+// If it were never, AxiosError<unknown> would NOT extend AxiosError<never>:
+type _C2b = Case2Error extends AxiosError<unknown> ? true : false
+const _c2b: _C2b = true
+
+// Ensure it is not specifically `never` — AxiosError<never> is a subtype of AxiosError<unknown>,
+// so check the other direction: AxiosError<unknown> should NOT extend AxiosError<never>
+type _C2c = AxiosError<unknown> extends AxiosError<never> ? false : true
+const _c2c: _C2c = true
+
+// ============================================================================
+// Case 3 — Two different 4xx bodies → union
+// ============================================================================
+
+type OpsUnionErrors = {
+  readonly createOrder: {
+    readonly parameters: { query?: never; header?: never; path?: never; cookie?: never }
+    readonly requestBody: {
+      readonly content: { readonly 'application/json': { readonly amount: number } }
+    }
+    readonly responses: {
+      readonly 201: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: { readonly 'application/json': { readonly orderId: string } }
+      }
+      /** @description Validation error — has its own shape */
+      readonly 422: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: {
+          readonly 'application/json': { readonly errors: readonly string[] }
+        }
+      }
+      /** @description Conflict — different shape from 422 */
+      readonly 409: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: {
+          readonly 'application/json': { readonly conflictingOrderId: string }
+        }
+      }
+    }
+  }
+}
+
+type Case3ErrorData = ApiErrorData<OpsUnionErrors, 'createOrder'>
+type Case3Error = ApiErrorOf<OpsUnionErrors, 'createOrder'>
+
+// Error data should be the union of the two JSON bodies
+type _C3a = Case3ErrorData extends { errors: readonly string[] } | { conflictingOrderId: string } ? true : false
+const _c3a: _C3a = true
+
+type _C3b = Case3Error extends AxiosError<{ errors: readonly string[] } | { conflictingOrderId: string }> ? true : false
+const _c3b: _C3b = true
+
+// ============================================================================
+// Case 4 — '4XX' and '5XX' range keys → body extracted
+//
+// openapi-typescript preserves range keys as string literals '4XX' / '5XX'.
+// ============================================================================
+
+type OpsRangeKeys = {
+  readonly callService: {
+    readonly parameters: { query?: never; header?: never; path?: never; cookie?: never }
+    readonly responses: {
+      readonly 200: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: { readonly 'application/json': { readonly result: string } }
+      }
+      /** @description Client error range */
+      readonly '4XX': {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: {
+          readonly 'application/json': { readonly clientError: string; readonly status: number }
+        }
+      }
+      /** @description Server error range */
+      readonly '5XX': {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: {
+          readonly 'application/json': { readonly serverError: string; readonly traceId: string }
+        }
+      }
+    }
+  }
+}
+
+type Case4ErrorData = ApiErrorData<OpsRangeKeys, 'callService'>
+type Case4Error = ApiErrorOf<OpsRangeKeys, 'callService'>
+
+// Both 4XX and 5XX bodies must be in the union
+type _C4a = Case4ErrorData extends { clientError: string; status: number } | { serverError: string; traceId: string }
+  ? true
+  : false
+const _c4a: _C4a = true
+
+type _C4b =
+  Case4Error extends AxiosError<{ clientError: string; status: number } | { serverError: string; traceId: string }>
+    ? true
+    : false
+const _c4b: _C4b = true
+
+// ============================================================================
+// Case 4c — Quoted numeric status keys (e.g. '404') are also treated as error keys.
+//
+// openapi-typescript normally emits unquoted numeric keys, but the extractor should
+// also handle the quoted string form so it is resilient to alternative emitters or
+// hand-written operation types.
+// ============================================================================
+
+type OpsQuotedNumericKey = {
+  readonly fetchItem: {
+    readonly parameters: { query?: never; header?: never; path?: never; cookie?: never }
+    readonly responses: {
+      readonly 200: {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: { readonly 'application/json': { readonly id: string } }
+      }
+      /** @description Not found — quoted string key */
+      readonly '404': {
+        readonly headers: { readonly [name: string]: unknown }
+        readonly content: { readonly 'application/json': { readonly notFoundCode: string } }
+      }
+    }
+  }
+}
+
+type Case4cErrorData = ApiErrorData<OpsQuotedNumericKey, 'fetchItem'>
+// '404' must be treated as an error key → body extracted, not unknown
+type _C4c = Case4cErrorData extends { notFoundCode: string } ? true : false
+const _c4c: _C4c = true
+
+// ============================================================================
+// Case 5 — skipGlobalError narrowed predicate: parameter IS AxiosError<TError>
+//
+// Under strict + strictFunctionTypes, the predicate is contravariant in its parameter.
+// TError on the option type is instantiated per operation so the narrowed callback
+// is the declared type and contravariance never arises.
+// ============================================================================
+
+// Define a concrete TError type to verify the predicate is narrowed, not AxiosError<unknown>
+interface OrderError {
+  errors: string[]
+}
+
+// QueryOptions<Response, QueryParams, OrderError>: skipGlobalError predicate
+// should accept (error: AxiosError<OrderError>) => boolean
+type NarrowedQueryOpts = QueryOptions<{ id: string }, Record<string, never>, OrderError>
+
+// Structural check: the field must accept a narrowed predicate
+type _C5aQuery = NarrowedQueryOpts extends {
+  skipGlobalError?: boolean | ((error: AxiosError<OrderError>) => boolean)
+}
+  ? true
+  : false
+const _c5aQuery: _C5aQuery = true
+
+// A correctly-typed narrowed predicate must compile without @ts-expect-error
+const _c5bQuery: NarrowedQueryOpts = {
+  skipGlobalError: (e: AxiosError<OrderError>) => {
+    // e.response?.data is OrderError — access .errors to prove the type is narrowed
+    const _errors: string[] | undefined = e.response?.data?.errors
+    void _errors
+    return _errors !== undefined && _errors.length > 0
+  },
+}
+
+// MutationOptions: same check
+type NarrowedMutationOpts = MutationOptions<
+  { id: string },
+  Record<string, never>,
+  never,
+  Record<string, never>,
+  OrderError
+>
+
+type _C5aMutation = NarrowedMutationOpts extends {
+  skipGlobalError?: boolean | ((error: AxiosError<OrderError>) => boolean)
+}
+  ? true
+  : false
+const _c5aMutation: _C5aMutation = true
+
+const _c5bMutation: NarrowedMutationOpts = {
+  skipGlobalError: (e: AxiosError<OrderError>) => {
+    const _errors: string[] | undefined = e.response?.data?.errors
+    void _errors
+    return false
+  },
+}
+
+// ============================================================================
+// Case 6 — error.value on a typed hook is AxiosError<T> | null;
+//          .response?.data is the declared shape
+//
+// Uses the real createApiClient from fixtures + uploadPetPic which has:
+//   422 → { message?: string }
+//   default → { message?: string }
+// so ApiErrorOf<operations, 'uploadPetPic'> = AxiosError<{ message?: string }>
+// ============================================================================
+
+// Verify ApiErrorOf for uploadPetPic (from fixture openapi-types)
+type UploadErrorData = ApiErrorData<operations, 'uploadPetPic'>
+type UploadError = ApiErrorOf<operations, 'uploadPetPic'>
+
+// Both 422 and default share { message?: string } → union collapses to { message?: string }
+type _C6a = UploadError extends AxiosError<{ message?: string }> ? true : false
+const _c6a: _C6a = true
+
+// QueryReturn.error: Ref<AxiosError<TError> | null>
+type UploadQueryReturn = QueryReturn<{ url: string }, { petId: string }, UploadErrorData>
+type _C6b = UploadQueryReturn['error'] extends Ref<AxiosError<{ message?: string }> | null> ? true : false
+const _c6b: _C6b = true
+
+// LazyQueryReturn.error should be Ref<AxiosError<TError> | null>
+// Merged from typed-error.ts — the only return-type threading case unique to that file.
+type UploadLazyQueryReturn = LazyQueryReturn<{ url: string }, { petId: string }, Record<string, never>, UploadErrorData>
+type _C6bLazy = UploadLazyQueryReturn['error'] extends Ref<AxiosError<{ message?: string }> | null> ? true : false
+const _c6bLazy: _C6bLazy = true
+
+// MutationReturn.error: Ref<AxiosError<TError> | null>
+type UploadMutationReturn = MutationReturn<
+  { url: string },
+  { petId: string },
+  FormData,
+  Record<string, never>,
+  UploadErrorData
+>
+type _C6c = UploadMutationReturn['error'] extends Ref<AxiosError<{ message?: string }> | null> ? true : false
+const _c6c: _C6c = true
+
+// Real-hook pattern: use createApiClient from fixtures to get a fully-typed hook return.
+// uploadPetPic.useMutation() should have error.value?.response?.data typed as { message?: string }.
+function testRealHookResponseData() {
+  const api = createApiClient(mockAxios)
+  const upload = api.uploadPetPic.useMutation()
+
+  // error is Ref<AxiosError<UploadErrorData> | null>
+  const errorRef = upload.error
+
+  // .response?.data should be typed as UploadErrorData = { message?: string } | undefined
+  // (undefined because AxiosError.response can be undefined)
+  const _data = errorRef.value?.response?.data
+
+  // If the type is right, _data should extend { message?: string } | undefined
+  type DataType = typeof _data
+  type _C6d = DataType extends { message?: string } | undefined ? true : false
+  const _c6d: _C6d = true
+  void _c6d
+
+  return errorRef
+}
+
+// ============================================================================
+// Exports (prevents TypeScript from pruning unused type aliases)
+// ============================================================================
+
+export type {
+  Case1ErrorData,
+  Case1Error,
+  Case2ErrorData,
+  Case2Error,
+  Case3ErrorData,
+  Case3Error,
+  Case4ErrorData,
+  Case4Error,
+  Case4cErrorData,
+  NarrowedQueryOpts,
+  NarrowedMutationOpts,
+  UploadErrorData,
+  UploadError,
+  UploadQueryReturn,
+  UploadLazyQueryReturn,
+  UploadMutationReturn,
+}
+
+export {
+  _c1a,
+  _c1b,
+  _c2a,
+  _c2b,
+  _c2c,
+  _c3a,
+  _c3b,
+  _c4a,
+  _c4b,
+  _c4c,
+  _c5aQuery,
+  _c5bQuery,
+  _c5aMutation,
+  _c5bMutation,
+  _c6a,
+  _c6b,
+  _c6bLazy,
+  _c6c,
+  testRealHookResponseData,
+}

--- a/tests/typing/error-policy.ts
+++ b/tests/typing/error-policy.ts
@@ -1,0 +1,145 @@
+/**
+ * Compile-time type tests for the error policy API.
+ *
+ * These tests never run — validated by `npm run types:test` (tsc --noEmit).
+ *
+ * Covers:
+ *  - skipGlobalError accepts boolean on useQuery and useMutation hooks (strict)
+ *  - skipGlobalError accepts predicate on useQuery and useMutation hooks (strict)
+ *  - ApiErrorPolicy callback receives unknown error (not AxiosError)
+ *  - ApiErrorContext shape
+ *  - createApiErrorCaches returns { queryCache, mutationCache }
+ */
+
+import { QueryCache, MutationCache } from '@tanstack/query-core'
+import type { AxiosError } from 'axios'
+import { createApiClient } from '../fixtures/api-client'
+import { mockAxios } from '../setup'
+import {
+  createApiErrorCaches,
+  type ApiErrorPolicy,
+  type ApiErrorContext,
+  type ApiErrorPolicyOptions,
+} from '@qualisero/openapi-endpoint'
+
+const api = createApiClient(mockAxios)
+
+// =============================================================================
+// Test 1: skipGlobalError boolean accepted on useQuery
+// =============================================================================
+function testSkipGlobalErrorBooleanOnQuery() {
+  const _q = api.listPets.useQuery({ skipGlobalError: true })
+  const _q2 = api.listPets.useQuery({ skipGlobalError: false })
+  return { _q, _q2 }
+}
+
+// =============================================================================
+// Test 2: skipGlobalError predicate accepted on useQuery (under strict)
+// =============================================================================
+function testSkipGlobalErrorPredicateOnQuery() {
+  const _q = api.listPets.useQuery({
+    skipGlobalError: (e: AxiosError<unknown>) => e.response?.status === 409,
+  })
+  return _q
+}
+
+// =============================================================================
+// Test 3: skipGlobalError boolean accepted on useMutation
+// =============================================================================
+function testSkipGlobalErrorBooleanOnMutation() {
+  const _m = api.createPet.useMutation({ skipGlobalError: true })
+  const _m2 = api.createPet.useMutation({ skipGlobalError: false })
+  return { _m, _m2 }
+}
+
+// =============================================================================
+// Test 4: skipGlobalError predicate accepted on useMutation (under strict)
+// =============================================================================
+function testSkipGlobalErrorPredicateOnMutation() {
+  const _m = api.createPet.useMutation({
+    skipGlobalError: (e: AxiosError<unknown>) => e.response?.status === 422,
+  })
+  return _m
+}
+
+// =============================================================================
+// Test 5: ApiErrorPolicy receives unknown (not AxiosError)
+// Demonstrates that the global callback is intentionally typed as unknown:
+// callers must narrow with isAxiosError inside the policy.
+// =============================================================================
+function testApiErrorPolicyReceivesUnknown() {
+  // error parameter is `unknown` — no .response access without narrowing
+  const policy: ApiErrorPolicy = (error: unknown, ctx: ApiErrorContext) => {
+    // ctx fields are well-typed
+    const _op: string = ctx.operationId
+    const _path: string = ctx.path
+    const _method = ctx.method
+    const _kind: 'query' | 'mutation' = ctx.kind
+    // error is unknown — cannot access properties directly without cast
+    const _err: unknown = error
+    void _op
+    void _path
+    void _method
+    void _kind
+    void _err
+  }
+  return policy
+}
+
+// =============================================================================
+// Test 6: ApiErrorPolicyOptions.onError is optional
+// =============================================================================
+function testApiErrorPolicyOptionsOptional() {
+  const opts1: ApiErrorPolicyOptions = {}
+  const opts2: ApiErrorPolicyOptions = {
+    onError: (error: unknown, ctx: ApiErrorContext) => {
+      void error
+      void ctx
+    },
+  }
+  return { opts1, opts2 }
+}
+
+// =============================================================================
+// Test 7: createApiErrorCaches returns { queryCache: QueryCache; mutationCache: MutationCache }
+// =============================================================================
+function testCreateApiErrorCachesReturnType() {
+  const { queryCache, mutationCache } = createApiErrorCaches({
+    onError: (error: unknown) => void error,
+  })
+
+  // Validate return types
+  const _qc: QueryCache = queryCache
+  const _mc: MutationCache = mutationCache
+  return { _qc, _mc }
+}
+
+// =============================================================================
+// Test 8: skipGlobalError wrong type is rejected on useQuery
+// =============================================================================
+function testSkipGlobalErrorWrongTypeRejected() {
+  // @ts-expect-error - skipGlobalError must be boolean or (AxiosError<unknown>) => boolean, not number
+  const _q = api.listPets.useQuery({ skipGlobalError: 42 })
+  return _q
+}
+
+// =============================================================================
+// Test 9: skipGlobalError wrong type is rejected on useMutation
+// =============================================================================
+function testSkipGlobalErrorWrongTypeRejectedOnMutation() {
+  // @ts-expect-error - skipGlobalError must be boolean or (AxiosError<unknown>) => boolean, not string
+  const _m = api.createPet.useMutation({ skipGlobalError: 'always' })
+  return _m
+}
+
+export {
+  testSkipGlobalErrorBooleanOnQuery,
+  testSkipGlobalErrorPredicateOnQuery,
+  testSkipGlobalErrorBooleanOnMutation,
+  testSkipGlobalErrorPredicateOnMutation,
+  testApiErrorPolicyReceivesUnknown,
+  testApiErrorPolicyOptionsOptional,
+  testCreateApiErrorCachesReturnType,
+  testSkipGlobalErrorWrongTypeRejected,
+  testSkipGlobalErrorWrongTypeRejectedOnMutation,
+}

--- a/tests/unit/api-usage.test.ts
+++ b/tests/unit/api-usage.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, computed, effectScope } from 'vue'
 import { QueryClient } from '@tanstack/vue-query'
 import type { QueryObserverResult } from '@tanstack/query-core'
-import type { AxiosResponse } from 'axios'
+import type { AxiosError, AxiosResponse } from 'axios'
 import { mockAxios } from '../setup'
 import { createApiClient } from '../fixtures/api-client'
 import { createTestScope } from '../helpers'
@@ -1099,10 +1099,11 @@ describe('API Usage Patterns', () => {
 
       const _refetchResult = _query.refetch()
 
-      // At the type level, refetch should return a Promise<QueryObserverResult<listPets.Response, Error>>
+      // At the type level, refetch should return a Promise<QueryObserverResult<listPets.Response, AxiosError<unknown>>>
+      // (TError defaults to unknown; previously was hard-coded as Error)
       // (In the mock environment, the result is undefined, but the type is correct)
       type RefetchRuntimeReturn = typeof _refetchResult
-      type ExpectedRuntimeReturn = Promise<QueryObserverResult<Types.listPets.Response, Error>>
+      type ExpectedRuntimeReturn = Promise<QueryObserverResult<Types.listPets.Response, AxiosError<unknown>>>
       const _forwardCheckRuntime: RefetchRuntimeReturn extends ExpectedRuntimeReturn ? true : false = true
       const _backwardCheckRuntime: ExpectedRuntimeReturn extends RefetchRuntimeReturn ? true : false = true
       expect(_forwardCheckRuntime && _backwardCheckRuntime).toBe(true)
@@ -1112,9 +1113,10 @@ describe('API Usage Patterns', () => {
       const _query = run(() => api.listPets.useQuery())
 
       // The refetch return type should flow from the OpenAPI spec: listPets returns Pet[]
-      // So refetch should return Promise<QueryObserverResult<Pet[], Error>>, not Promise<void>
+      // So refetch should return Promise<QueryObserverResult<Pet[], AxiosError<unknown>>>, not Promise<void>
+      // (TError defaults to unknown; previously was hard-coded as Error)
       type RefetchReturn = ReturnType<typeof _query.refetch>
-      type ExpectedReturn = Promise<QueryObserverResult<Types.listPets.Response, Error>>
+      type ExpectedReturn = Promise<QueryObserverResult<Types.listPets.Response, AxiosError<unknown>>>
 
       // Compile-time check: the return types must be assignable both ways (i.e., equivalent)
       const _forwardCheck: RefetchReturn extends ExpectedReturn ? true : false = true

--- a/tests/unit/cli-integration.test.ts
+++ b/tests/unit/cli-integration.test.ts
@@ -271,7 +271,7 @@ describe('CLI Integration Tests', () => {
 // depend on a pre-existing dist/ directory (which is gitignored and absent in CI).
 // ────────────────────────────────────────────────────────────────────────────
 
-describe('CLI --enum-case flag (real subprocess)', () => {
+describe('CLI --enum-case flag (real subprocess)', { timeout: 30_000 }, () => {
   const CLI = path.join(os.tmpdir(), 'openapi-cli-test-bundle.js')
   const TOY_SPEC = path.join(process.cwd(), 'tests/fixtures/toy-openapi.json')
   const COLLISION_SPEC = path.join(process.cwd(), 'tests/fixtures/collision-openapi.json')
@@ -403,5 +403,203 @@ describe('CLI --enum-case flag (real subprocess)', () => {
     for (const file of generatedFiles) {
       expect(fs.existsSync(path.join(outDir, file))).toBe(false)
     }
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// Error-policy and typed-error generator tests (real CLI subprocess)
+// These tests verify the §3 generator changes that are unrelated to --enum-case.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('CLI error-policy and typed-error output (real subprocess)', { timeout: 30_000 }, () => {
+  const CLI = path.join(os.tmpdir(), 'openapi-cli-test-bundle.js')
+  const TOY_SPEC = path.join(process.cwd(), 'tests/fixtures/toy-openapi.json')
+  const outDir = '/tmp/openapi-error-policy-out'
+
+  beforeAll(() => {
+    buildSync({
+      entryPoints: [path.join(process.cwd(), 'src/cli.ts')],
+      bundle: true,
+      platform: 'node',
+      outfile: CLI,
+    })
+  })
+
+  beforeEach(() => {
+    if (fs.existsSync(outDir)) {
+      fs.rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  afterEach(() => {
+    if (fs.existsSync(outDir)) {
+      fs.rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  it('generated api-operations.ts includes ApiErrorData and ApiError type helpers', () => {
+    const result = spawnSync('node', [CLI, TOY_SPEC, outDir], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+
+    expect(result.status).toBe(0)
+
+    const opsContent = fs.readFileSync(path.join(outDir, 'api-operations.ts'), 'utf8')
+
+    // Import aliases
+    expect(opsContent).toContain('ApiErrorData as _ApiErrorData')
+    expect(opsContent).toContain('ApiErrorOf as _ApiErrorOf')
+
+    // Type helpers
+    expect(opsContent).toContain('export type ApiErrorData<K extends AllOps> = _ApiErrorData<operations, K>')
+    expect(opsContent).toContain('export type ApiError<K extends AllOps> = _ApiErrorOf<operations, K>')
+  })
+
+  it('generated api-client.ts helpers include ApiErrorData import and ErrorData threading', () => {
+    const result = spawnSync('node', [CLI, TOY_SPEC, outDir], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+
+    expect(result.status).toBe(0)
+
+    const clientContent = fs.readFileSync(path.join(outDir, 'api-client.ts'), 'utf8')
+
+    // ApiErrorData imported from api-operations
+    expect(clientContent).toContain('ApiErrorData')
+
+    // ErrorData type alias in each helper
+    // There are 4 helpers so ErrorData must appear multiple times
+    const errorDataCount = (clientContent.match(/type ErrorData = ApiErrorData<Op>/g) ?? []).length
+    expect(errorDataCount).toBe(4)
+
+    // Verify threading into return types (both query and mutation flavours)
+    expect(clientContent).toContain('QueryReturn<Response, Record<string, never>, ErrorData>')
+    expect(clientContent).toContain(
+      'MutationReturn<Response, Record<string, never>, RequestBody, QueryParams, ErrorData>',
+    )
+  })
+
+  it('reserved-name Error schema is emitted as ErrorSchema in api-schemas.ts', () => {
+    const ERROR_SPEC = path.join(process.cwd(), 'tests/fixtures/error-schema-openapi.json')
+    const result = spawnSync('node', [CLI, ERROR_SPEC, outDir], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+
+    expect(result.status).toBe(0)
+
+    const schemasContent = fs.readFileSync(path.join(outDir, 'api-schemas.ts'), 'utf8')
+
+    // Must emit ErrorSchema alias, not plain Error (which would shadow the global)
+    expect(schemasContent).toContain("export type ErrorSchema = components['schemas']['Error']")
+    expect(schemasContent).not.toContain('export type Error = ')
+
+    // The comment pointing to the original schema name must be present
+    expect(schemasContent).toContain('// Schema: Error')
+
+    // Non-reserved names should be unaffected
+    expect(schemasContent).toContain("export type Item = components['schemas']['Item']")
+    expect(schemasContent).toContain("export type NewItem = components['schemas']['NewItem']")
+  })
+
+  it('generated api-client.ts cfg literals include operationId for every operation', () => {
+    const result = spawnSync('node', [CLI, TOY_SPEC, outDir], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+
+    expect(result.status).toBe(0)
+
+    const clientContent = fs.readFileSync(path.join(outDir, 'api-client.ts'), 'utf8')
+
+    // Every operation in toy-openapi.json must appear as operationId: '<id>' in a cfg literal.
+    const expectedOps = [
+      'listPets',
+      'createPet',
+      'getPet',
+      'updatePet',
+      'deletePet',
+      'listUserPets',
+      'searchPets',
+      'uploadPetPic',
+    ]
+    for (const opId of expectedOps) {
+      expect(clientContent).toContain(`operationId: '${opId}'`)
+    }
+
+    // Sanity-check that the cfg field appears on the same line as path and method.
+    // Example: { path: '/pets', method: HttpMethod.GET, listPath: null, operationId: 'listPets' }
+    expect(clientContent).toMatch(/path: '\/pets', method: HttpMethod\.GET, listPath: null, operationId: 'listPets'/)
+    expect(clientContent).toMatch(
+      /path: '\/pets', method: HttpMethod\.POST, listPath: '\/pets', operationId: 'createPet'/,
+    )
+  })
+
+  it('generated output type-checks cleanly under tsc --strict (no TS errors in generated files)', () => {
+    // Generate from the toy spec.
+    const genResult = spawnSync('node', [CLI, TOY_SPEC, outDir], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+    expect(genResult.status).toBe(0)
+
+    // Pin the enum self-alias fix independently of the type-check below:
+    // api-enums.ts must never emit `export const X = X` redeclarations.
+    const enumsContent = fs.readFileSync(path.join(outDir, 'api-enums.ts'), 'utf8')
+    expect(enumsContent).not.toMatch(/export const (\w+) = \1$/m)
+
+    // Write a temporary tsconfig in the project root so baseUrl-relative paths
+    // and node_modules are accessible. External packages need explicit paths because
+    // tsc walks up from the source file location (/tmp/...) to find node_modules,
+    // not from the tsconfig directory (project root).
+    const projRoot = process.cwd()
+    const tmpConfig = path.join(projRoot, `tsconfig-gencheck-${Date.now()}.json`)
+    const tsconfig = {
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        strict: true,
+        noEmit: true,
+        // skipLibCheck mirrors the project's own tsconfig so external lib
+        // declaration errors don't mask real generated-file errors.
+        skipLibCheck: true,
+        baseUrl: '.',
+        paths: {
+          // Resolve the package to the TypeScript sources so the check works
+          // on a clean checkout (CI runs tests without a prior build) and
+          // validates against current src/, not a possibly stale dist/.
+          '@qualisero/openapi-endpoint': ['src/index'],
+          // External deps: listed explicitly because TypeScript resolves
+          // node_modules by walking up from the source file directory
+          // (/tmp/...), not from the tsconfig directory (project root).
+          axios: ['node_modules/axios/index'],
+          vue: ['node_modules/vue/dist/vue'],
+          '@tanstack/vue-query': ['node_modules/@tanstack/vue-query/build/legacy/index'],
+        },
+      },
+      include: [`${outDir}/**/*.ts`],
+    }
+    fs.writeFileSync(tmpConfig, JSON.stringify(tsconfig, null, 2))
+
+    let tscResult
+    try {
+      tscResult = spawnSync('npx', ['tsc', '--project', tmpConfig], {
+        cwd: projRoot,
+        encoding: 'utf8',
+        timeout: 60_000,
+      })
+    } finally {
+      fs.unlinkSync(tmpConfig)
+    }
+
+    const output = (tscResult.stdout ?? '') + (tscResult.stderr ?? '')
+    if (tscResult.status !== 0) {
+      // Surface errors in the failure message for easier debugging.
+      throw new Error(`tsc type-check of generated files failed:\n${output}`)
+    }
+    expect(tscResult.status).toBe(0)
   })
 })

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1005,7 +1005,7 @@ export type OperationId = keyof OpenApiOperations
  */
 function _queryNoParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type Response = ApiResponse<Op>
@@ -1072,7 +1072,7 @@ function _queryNoParams<Op extends AllOps>(
  */
 function _queryWithParams<Op extends AllOps>(
   base: _Config,
-  cfg: { path: string; method: HttpMethod; listPath: string | null },
+  cfg: { path: string; method: HttpMethod; listPath: string | null; operationId?: string },
   enums: Record<string, unknown>,
 ) {
   type PathParams = ApiPathParams<Op>

--- a/tests/unit/error-policy.test.ts
+++ b/tests/unit/error-policy.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Runtime tests for createApiErrorCaches error policy
+ *
+ * Numbered to match the plan's §3.5 test list:
+ * (1) onError fires exactly once after all retries exhaust
+ * (2) skipGlobalError:true → zero calls
+ * (3) predicate: suppressed when true, fires when false, receives error
+ * (4) unstamped ad-hoc query on same client → zero calls
+ * (5) caller-supplied meta survives the stamp
+ * (6) mutation error fires once with kind:'mutation'
+ * (7) swallowing errorHandler → zero onError calls (query resolves null)
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { QueryClient } from '@tanstack/vue-query'
+import type { AxiosError } from 'axios'
+import { createApiErrorCaches, ERROR_POLICY_META_KEY, type ApiErrorContext } from '@qualisero/openapi-endpoint'
+import { mockAxios } from '../setup'
+import { createTestScope } from '../helpers'
+
+// ---------------------------------------------------------------------------
+// Helper: build a QueryClient that uses the error caches.
+// The default options mirror createTestQueryClient() so existing helpers work.
+// ---------------------------------------------------------------------------
+function makeErrorClient(onError: (error: unknown, ctx: ApiErrorContext) => void) {
+  const { queryCache, mutationCache } = createApiErrorCaches({ onError })
+  return new QueryClient({
+    queryCache,
+    mutationCache,
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+// Shared axios errors used across tests
+const error500 = { isAxiosError: true, response: { status: 500 }, message: 'Server error' }
+const error409 = { isAxiosError: true, response: { status: 409 }, message: 'Conflict' }
+const error422 = { isAxiosError: true, response: { status: 422 }, message: 'Unprocessable' }
+
+describe('createApiErrorCaches — error policy', () => {
+  // -------------------------------------------------------------------------
+  // (1) retry:2 → 3 axios calls, exactly 1 onError
+  // -------------------------------------------------------------------------
+  it('(1) fires onError exactly once for a query with retry:2 (3 axios calls → 1 onError)', async () => {
+    vi.useFakeTimers()
+    try {
+      const onError = vi.fn()
+      const { queryCache, mutationCache } = createApiErrorCaches({ onError })
+      const qc = new QueryClient({
+        queryCache,
+        mutationCache,
+        // retryDelay:0 avoids real time waits; retry is overridden per-hook
+        defaultOptions: { queries: { gcTime: 0, staleTime: 0, retryDelay: 0 } },
+      })
+
+      mockAxios.mockRejectedValue(error500)
+
+      const { api, run, scope } = createTestScope(mockAxios, qc)
+
+      // retry:2 overrides no4xxRetry (spread comes after retry:no4xxRetry in queryOptions)
+      run(() => api.listPets.useQuery({ retry: 2, retryDelay: 0 }))
+
+      // Advance through all retry timers and flush resulting promises
+      await vi.runAllTimersAsync()
+
+      expect(mockAxios).toHaveBeenCalledTimes(3) // initial + 2 retries
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith(
+        error500,
+        expect.objectContaining({
+          operationId: 'listPets',
+          path: '/pets',
+          method: 'GET',
+          kind: 'query',
+        }),
+      )
+
+      scope.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // (2) skipGlobalError:true → zero onError calls
+  // -------------------------------------------------------------------------
+  it('(2) skipGlobalError:true → zero onError calls', async () => {
+    const onError = vi.fn()
+    const qc = makeErrorClient(onError)
+    mockAxios.mockRejectedValueOnce(error500)
+
+    const { api, run, scope } = createTestScope(mockAxios, qc)
+    run(() => api.listPets.useQuery({ skipGlobalError: true }))
+    await flushPromises()
+
+    expect(onError).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // (3) predicate: suppressed when returns true; fires when returns false;
+  //     the error object is forwarded to onError when it fires
+  // -------------------------------------------------------------------------
+  it('(3) predicate: suppressed when true, fires when false, forwards the error', async () => {
+    // Sub-test A: predicate returns true (409) → suppress
+    {
+      const onError = vi.fn()
+      const qc = makeErrorClient(onError)
+      mockAxios.mockRejectedValueOnce(error409)
+      const { api, run, scope } = createTestScope(mockAxios, qc)
+      // retry:false overrides no4xxRetry so 4xx doesn't retry AND 5xx fails cleanly
+      run(() =>
+        api.listPets.useQuery({
+          skipGlobalError: (e: AxiosError<unknown>) => e.response?.status === 409,
+          retry: false,
+        }),
+      )
+      await flushPromises()
+      expect(onError).not.toHaveBeenCalled()
+      scope.stop()
+    }
+
+    // Sub-test B: predicate returns false (500) → onError fires, receives error;
+    //             the query itself still enters error state (never-swallows contract)
+    {
+      const onError = vi.fn()
+      const qc = makeErrorClient(onError)
+      mockAxios.mockRejectedValueOnce(error500)
+      const { api, run, scope } = createTestScope(mockAxios, qc)
+      // retry:false ensures the 5xx error is not retried (no4xxRetry would retry 5xx)
+      const query = run(() =>
+        api.listPets.useQuery({
+          skipGlobalError: (e: AxiosError<unknown>) => e.response?.status === 409,
+          retry: false,
+        }),
+      )
+      await flushPromises()
+      expect(onError).toHaveBeenCalledTimes(1)
+      // The error forwarded is the original rejection value
+      expect(onError.mock.calls[0][0]).toBe(error500)
+      // The promise still rejects: onError is observe-only, it never swallows.
+      expect(query.isError.value).toBe(true)
+      scope.stop()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // (4) zero onError calls for an ad-hoc unstamped query on the same client
+  // -------------------------------------------------------------------------
+  it('(4) zero onError calls for an unstamped ad-hoc query on the same client', async () => {
+    const onError = vi.fn()
+    const { queryCache, mutationCache } = createApiErrorCaches({ onError })
+    const qc = new QueryClient({
+      queryCache,
+      mutationCache,
+      defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+    })
+
+    mockAxios.mockRejectedValueOnce(error500)
+
+    // Direct fetchQuery call without any library stamp in meta
+    await qc
+      .fetchQuery({
+        queryKey: ['ad-hoc-unstamped'],
+        queryFn: () => (mockAxios as any)({ method: 'get', url: '/external' }),
+        retry: false,
+        // No meta → no stamp → cache onError returns immediately without calling opts.onError
+      })
+      .catch(() => {
+        /* expected to reject */
+      })
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // (5) caller-supplied meta keys survive the error policy stamp
+  // -------------------------------------------------------------------------
+  it('(5) caller-supplied meta survives the error policy stamp', async () => {
+    const onError = vi.fn()
+    const qc = makeErrorClient(onError)
+
+    const { api, run, scope } = createTestScope(mockAxios, qc)
+    // Mount with caller-supplied meta; default mockAxios resolves { data: {} }
+    run(() => api.listPets.useQuery({ meta: { myKey: 'myValue', anotherKey: 42 } }))
+    await flushPromises()
+
+    const queries = qc.getQueryCache().getAll()
+    expect(queries.length).toBeGreaterThan(0)
+    const meta = queries[0].meta as Record<string, unknown>
+    // Caller keys must survive
+    expect(meta?.myKey).toBe('myValue')
+    expect(meta?.anotherKey).toBe(42)
+    // Stamp must also be present
+    expect(meta?.[ERROR_POLICY_META_KEY]).toBeDefined()
+
+    scope.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // (5b) Ref-valued meta is unwrapped before spreading (toValue guard)
+  // -------------------------------------------------------------------------
+  it('(5b) Ref-valued meta keys survive the stamp (toValue unwrap)', async () => {
+    const onError = vi.fn()
+    const qc = makeErrorClient(onError)
+    const { api, run, scope } = createTestScope(mockAxios, qc)
+    // as any: TanStack's QueryMeta is Record<string,unknown>; passing a Ref object
+    // satisfies the structural type (all Ref properties extend unknown) but the
+    // intent is to test runtime toValue() unwrapping, so we cast for clarity.
+    run(() => api.listPets.useQuery({ meta: ref({ refKey: 'fromRef' }) } as any))
+    await flushPromises()
+    const queries = qc.getQueryCache().getAll()
+    expect(queries.length).toBeGreaterThan(0)
+    const meta = queries[0].meta as Record<string, unknown>
+    // The ref was unwrapped by toValue(); the key must be present as a plain value.
+    expect(meta?.refKey).toBe('fromRef')
+    // __v_isRef must NOT be present (would indicate the ref itself was spread).
+    expect(meta?.__v_isRef).toBeUndefined()
+    scope.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // (6) mutation error fires onError exactly once with kind:'mutation'
+  // -------------------------------------------------------------------------
+  it('(6) mutation error fires onError once with kind:mutation', async () => {
+    const onError = vi.fn()
+    const { queryCache, mutationCache } = createApiErrorCaches({ onError })
+    const qc = new QueryClient({
+      queryCache,
+      mutationCache,
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, gcTime: 0, staleTime: 0 } },
+    })
+
+    mockAxios.mockRejectedValueOnce(error422)
+
+    const { api, run, scope } = createTestScope(mockAxios, qc)
+    const mutation = run(() => api.createPet.useMutation())
+
+    await mutation.mutateAsync({ data: { name: 'test' } } as any).catch(() => {
+      /* expected to reject */
+    })
+    await flushPromises()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(
+      error422,
+      expect.objectContaining({
+        operationId: 'createPet',
+        path: '/pets',
+        method: 'POST',
+        kind: 'mutation',
+      }),
+    )
+
+    scope.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // (7) swallowing errorHandler → zero onError calls (query resolves null)
+  // -------------------------------------------------------------------------
+  it('(7) swallowing errorHandler yields zero onError calls and query resolves', async () => {
+    const onError = vi.fn()
+    const qc = makeErrorClient(onError)
+
+    // Mock an axios-shaped error so the errorHandler guard fires
+    mockAxios.mockRejectedValueOnce(error500)
+
+    const { api, run, scope } = createTestScope(mockAxios, qc)
+    // errorHandler swallows: returns undefined → buildQueryFn returns null → query resolves
+    const query = run(() =>
+      api.listPets.useQuery({
+        errorHandler: vi.fn().mockResolvedValue(undefined),
+      }),
+    )
+    await flushPromises()
+
+    // The cache never sees a rejection (errorHandler swallowed it → queryFn
+    // returned null to satisfy TanStack v5's no-undefined constraint) →
+    // onError is never called.
+    expect(onError).not.toHaveBeenCalled()
+    // The query resolved (not error state); data.value is null (the swallowed
+    // path returns null to satisfy TanStack v5's non-undefined requirement).
+    expect(query.isError.value).toBe(false)
+    expect(query.data.value).toBe(null)
+
+    scope.stop()
+  })
+})

--- a/tests/unit/lazy-query.test.ts
+++ b/tests/unit/lazy-query.test.ts
@@ -5,6 +5,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, effectScope, computed } from 'vue'
 import { flushPromises } from '@vue/test-utils'
+import { QueryClient } from '@tanstack/vue-query'
+import { createApiErrorCaches } from '@qualisero/openapi-endpoint'
 import { mockAxios } from '../setup'
 import { createTestScope } from '../helpers'
 import { createApiClient } from '../fixtures/api-client'
@@ -106,16 +108,81 @@ describe('Lazy Query', () => {
     })
 
     it('should set isError and error after axios rejects', async () => {
-      const testError = new Error('Network error')
+      // Use an axios-shaped 4xx error. no4xxRetry returns false for 4xx, so
+      // there is exactly one attempt — no setTimeout-based retry delays.
+      const testError = { isAxiosError: true, response: { status: 400 }, message: 'Bad Request' }
       mockAxios.mockRejectedValueOnce(testError)
 
       const query = scope.run(() => api.listPets.useLazyQuery())!
 
-      await expect(query.fetch()).rejects.toThrow('Network error')
+      await expect(query.fetch()).rejects.toMatchObject({ message: 'Bad Request' })
       await flushPromises()
 
       expect(query.isError.value).toBe(true)
       expect(query.error.value).toBeTruthy()
+    })
+
+    it('(§2.2) lazy fetch() on 404 makes exactly one axios call even with a retry:3 QueryClient', async () => {
+      // A retry:3 client proves the fix: without no4xxRetry on the lazy fetchQuery,
+      // the 404 would retry 3× → 4 calls; with the fix applied, only 1 call is made.
+      const retryClient = new QueryClient({
+        defaultOptions: { queries: { retry: 3, retryDelay: 0, gcTime: 0 } },
+      })
+      const error404 = { isAxiosError: true, response: { status: 404 }, message: 'Not Found' }
+      mockAxios.mockRejectedValueOnce(error404)
+
+      const { scope: testScope } = createTestScope(mockAxios, retryClient)
+      const query = testScope.run(() => createApiClient(mockAxios, retryClient).listPets.useLazyQuery())!
+
+      await expect(query.fetch()).rejects.toMatchObject({ message: 'Not Found' })
+      await flushPromises()
+
+      // no4xxRetry returns false for 4xx → exactly 1 call, no retries
+      expect(mockAxios).toHaveBeenCalledTimes(1)
+      expect(query.isError.value).toBe(true)
+
+      testScope.stop()
+    })
+
+    it('(§2.2b) lazy fetch() with a plain Error retries and then rejects', async () => {
+      // A non-axios error passes no4xxRetry's isAxiosError guard → retries are allowed.
+      // This pins that the lazy path uses no4xxRetry consistently with useQuery.
+      vi.useFakeTimers()
+      try {
+        const retryClient = new QueryClient({
+          defaultOptions: { queries: { retry: 3, retryDelay: 0, gcTime: 0 } },
+        })
+        const networkError = new Error('Network error')
+        // Queue 4 rejections: 1 initial + 3 retries
+        mockAxios
+          .mockRejectedValueOnce(networkError)
+          .mockRejectedValueOnce(networkError)
+          .mockRejectedValueOnce(networkError)
+          .mockRejectedValueOnce(networkError)
+
+        const { scope: testScope } = createTestScope(mockAxios, retryClient)
+        const query = testScope.run(() => createApiClient(mockAxios, retryClient).listPets.useLazyQuery())!
+
+        const fetchPromise = query.fetch()
+        // Suppress unhandled-rejection noise while timers are advancing:
+        // the promise rejects during timer advancement and Node warns if no
+        // handler is attached yet. Attaching a no-op catch here silences the
+        // warning without affecting the assertion below.
+        fetchPromise.catch(() => {})
+        // Advance through all retry timeouts (retryDelay: 0 → setTimeout(0, …) × 3)
+        await vi.runAllTimersAsync()
+
+        await expect(fetchPromise).rejects.toThrow('Network error')
+        await flushPromises()
+
+        // 1 initial + 3 retries = 4 total calls
+        expect(mockAxios).toHaveBeenCalledTimes(4)
+        expect(query.isError.value).toBe(true)
+
+        testScope.stop()
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 
@@ -224,6 +291,38 @@ describe('Lazy Query', () => {
           },
         }),
       )
+    })
+  })
+
+  describe('useLazyQuery - error policy', () => {
+    it('(§10) lazy + skipGlobalError:true → zero onError calls, fetch still rejects', async () => {
+      // Build a client wired with the error policy
+      const onError = vi.fn()
+      const { queryCache, mutationCache } = createApiErrorCaches({ onError })
+      const qc = new QueryClient({
+        queryCache,
+        mutationCache,
+        defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+      })
+
+      const error404 = { isAxiosError: true, response: { status: 404 }, message: 'Not Found' }
+      mockAxios.mockRejectedValueOnce(error404)
+
+      const { scope: testScope } = createTestScope(mockAxios, qc)
+      const query = testScope.run(() =>
+        createApiClient(mockAxios, qc).listPets.useLazyQuery({ skipGlobalError: true }),
+      )!
+
+      // fetch() must reject (the promise is never swallowed)
+      await expect(query.fetch()).rejects.toMatchObject({ message: 'Not Found' })
+      await flushPromises()
+
+      // skipGlobalError suppresses the global side-effect — zero onError calls
+      expect(onError).not.toHaveBeenCalled()
+      // The query is in error state (reject propagated normally)
+      expect(query.isError.value).toBe(true)
+
+      testScope.stop()
     })
   })
 })


### PR DESCRIPTION
## Summary

Single combined release **0.25.0** delivering a first-class error channel, per the plan of record (error policy + typed errors lumped into one version by maintainer decision).

### Added
- **`createApiErrorCaches({ onError })`**: build your `QueryClient`'s caches from it to get a global error policy that fires **once per logical failure, after retries, observe-only** (the promise always rejects). The callback receives `(error, ctx)` with `operationId`, `path`, `method`, and `kind: 'query' | 'mutation'`. Ad-hoc queries without the library's meta stamp are untouched.
- **`skipGlobalError`** per-call opt-out on both `useQuery` and `useMutation` options: `true` always suppresses the global policy; a predicate (typed to the operation's declared error body) suppresses selectively (e.g. only on 409). Rejection is unaffected.
- **Typed error channel**: `error.value` is now `AxiosError<TError>` carrying the operation's declared 4xx/5xx/`default` JSON body (incl. `'4XX'`/`'5XX'` range keys; falls back to `unknown`, never `never`). Generated `api-operations.ts` exports `ApiErrorData<Op>` / `ApiError<Op>`.
- `operationId` emitted into every generated endpoint config.

### Changed (minor-breaking edge)
- Error type widens from `Error` to `AxiosError<TError>` (default `unknown`) across query/mutation options and returns. `error.value.message` still works (`AxiosError extends Error`); code annotated `: Error` may need updating.
- Reserved schema names (e.g. a schema literally named `Error`) are emitted with a `Schema` suffix so they don't shadow globals.

### Deprecated
- `errorHandler`: swallows unless it rethrows and fires per retry attempt. Its swallow path now resolves `null` instead of tripping TanStack v5's *Query data cannot be undefined* error state (documented in CHANGELOG).

### Fixed
- `useEndpointLazyQuery`'s `fetch()` now applies the standard no-retry-on-4xx policy (previously inherited the client default and could retry a 404 three times).
- Generated `api-enums.ts` no longer emits `export const X = X` self-alias redeclarations.

### Test hardening
- New `tsc --strict` regression guard over freshly generated CLI output (runs on a clean checkout, resolves the package to `src/`), so generator/consumer drift cannot pass CI again.
- Mutation-verified regression tests for the lazy-retry fix and status-key extraction; mutual-identity `Eq<>` typing assertions enforce the `unknown`-not-`never` contract.

### Notes for reviewers
- `ExtractResponseData` was deliberately **not** refactored to the mapped-key style: it would turn first-match 200-wins semantics into a union (behaviour change). Recorded in the implementation notes.
- Pre-existing, out of scope (follow-up issues welcome): CI doesn't run `types:test`; three fixtures carry a pre-existing `.js` import-suffix divergence; a spec containing both `Error` and `ErrorSchema` schemas still collides.

## Validation
- `npm run check` (types, types:test, lint, format) green
- `npm run test:run`: 454/454, 18 files
- Fresh CLI generation from the toy spec compiles clean under `tsc --strict` with no prior build